### PR TITLE
Implement lote registration and listing

### DIFF
--- a/src/pages/ConsumoReposicao/CadastroLotes.jsx
+++ b/src/pages/ConsumoReposicao/CadastroLotes.jsx
@@ -1,10 +1,199 @@
-import React from "react";
+import React, { useEffect, useRef, useState } from "react";
+import Select from "react-select";
 
-export default function CadastroLotes() {
+export default function CadastroLotes({ onFechar, onSalvar }) {
+  const [dados, setDados] = useState({
+    nome: "",
+    funcao: "",
+    nivelProducao: "",
+    tipoTratamento: "",
+    motivoDescarte: "",
+    descricao: "",
+    ativo: true,
+  });
+  const refs = useRef([]);
+
+  useEffect(() => {
+    refs.current[0]?.focus();
+    const esc = (e) => e.key === "Escape" && onFechar?.();
+    window.addEventListener("keydown", esc);
+    return () => window.removeEventListener("keydown", esc);
+  }, [onFechar]);
+
+  const funcoes = [
+    "Lactação",
+    "Tratamento",
+    "Descarte",
+    "Secagem",
+    "Pré-parto",
+    "Novilhas",
+    "Outro",
+  ];
+  const niveis = ["Alta Produção", "Média Produção", "Baixa Produção"];
+  const tratamentos = ["Mastite", "Pós-parto", "Outro"];
+  const motivos = ["Produção baixa", "Lesão", "Problemas podais", "Outro"];
+
+  const handleChange = (campo, valor) => {
+    setDados((prev) => ({ ...prev, [campo]: valor }));
+  };
+
+  const validar = () => {
+    if (!dados.nome.trim()) return false;
+    if (!dados.funcao) return false;
+    if (dados.funcao === "Lactação" && !dados.nivelProducao) return false;
+    if (dados.funcao === "Tratamento" && !dados.tipoTratamento) return false;
+    if (dados.funcao === "Descarte" && !dados.motivoDescarte) return false;
+    return true;
+  };
+
+  const salvar = () => {
+    if (!validar()) {
+      alert("Preencha todos os campos obrigatórios.");
+      return;
+    }
+    const lista = JSON.parse(localStorage.getItem("lotes") || "[]");
+    const atualizada = [...lista, dados];
+    localStorage.setItem("lotes", JSON.stringify(atualizada));
+    window.dispatchEvent(new Event("lotesAtualizados"));
+    onSalvar?.(dados);
+    onFechar?.();
+  };
+
   return (
-    <div className="p-4">
-      <h3 className="text-lg font-bold text-blue-800 mb-4">➕ Cadastro de Lotes</h3>
-      <p>Em breve: entrada de produtos com lote, validade e valor.</p>
+    <div style={overlay}>
+      <div style={modal}>
+        <div style={header}>➕ Cadastro de Lotes</div>
+        <div style={{ padding: "1.5rem", display: "flex", flexDirection: "column", gap: "1rem" }}>
+          <div>
+            <label>Nome</label>
+            <input
+              ref={(el) => (refs.current[0] = el)}
+              value={dados.nome}
+              onChange={(e) => handleChange("nome", e.target.value)}
+              style={input()}
+            />
+          </div>
+          <div>
+            <label>Função do Lote *</label>
+            <Select
+              options={funcoes.map((f) => ({ value: f, label: f }))}
+              value={dados.funcao ? { value: dados.funcao, label: dados.funcao } : null}
+              onChange={(op) => handleChange("funcao", op?.value || "")}
+              className="react-select-container"
+              classNamePrefix="react-select"
+              placeholder="Selecione..."
+            />
+          </div>
+          {dados.funcao === "Lactação" && (
+            <div>
+              <label>Nível Produtivo *</label>
+              <Select
+                options={niveis.map((n) => ({ value: n, label: n }))}
+                value={dados.nivelProducao ? { value: dados.nivelProducao, label: dados.nivelProducao } : null}
+                onChange={(op) => handleChange("nivelProducao", op?.value || "")}
+                className="react-select-container"
+                classNamePrefix="react-select"
+                placeholder="Selecione..."
+              />
+            </div>
+          )}
+          {dados.funcao === "Tratamento" && (
+            <div>
+              <label>Tipo de Tratamento *</label>
+              <Select
+                options={tratamentos.map((t) => ({ value: t, label: t }))}
+                value={dados.tipoTratamento ? { value: dados.tipoTratamento, label: dados.tipoTratamento } : null}
+                onChange={(op) => handleChange("tipoTratamento", op?.value || "")}
+                className="react-select-container"
+                classNamePrefix="react-select"
+                placeholder="Selecione..."
+              />
+            </div>
+          )}
+          {dados.funcao === "Descarte" && (
+            <div>
+              <label>Motivo do Descarte *</label>
+              <Select
+                options={motivos.map((m) => ({ value: m, label: m }))}
+                value={dados.motivoDescarte ? { value: dados.motivoDescarte, label: dados.motivoDescarte } : null}
+                onChange={(op) => handleChange("motivoDescarte", op?.value || "")}
+                className="react-select-container"
+                classNamePrefix="react-select"
+                placeholder="Selecione..."
+              />
+            </div>
+          )}
+          <div>
+            <label>Descrição</label>
+            <textarea
+              value={dados.descricao}
+              onChange={(e) => handleChange("descricao", e.target.value)}
+              style={{ ...input(), height: "80px" }}
+            />
+          </div>
+          <div style={{ display: "flex", justifyContent: "flex-end", gap: "1rem", marginTop: "0.5rem" }}>
+            <button onClick={onFechar} style={botaoCancelar}>Cancelar</button>
+            <button onClick={salvar} style={botaoConfirmar}>Salvar</button>
+          </div>
+        </div>
+      </div>
     </div>
   );
 }
+
+const overlay = {
+  position: "fixed",
+  inset: 0,
+  backgroundColor: "rgba(0,0,0,0.6)",
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  zIndex: 9999,
+};
+
+const modal = {
+  backgroundColor: "#fff",
+  borderRadius: "1rem",
+  width: "420px",
+  maxHeight: "90vh",
+  overflowY: "auto",
+  fontFamily: "Poppins, sans-serif",
+};
+
+const header = {
+  background: "#1e40af",
+  color: "white",
+  padding: "1rem 1.5rem",
+  fontWeight: "bold",
+  fontSize: "1.1rem",
+  borderTopLeftRadius: "1rem",
+  borderTopRightRadius: "1rem",
+  textAlign: "center",
+};
+
+const input = () => ({
+  width: "100%",
+  padding: "0.6rem",
+  fontSize: "0.95rem",
+  borderRadius: "0.5rem",
+  border: "1px solid #ccc",
+});
+
+const botaoCancelar = {
+  background: "#f3f4f6",
+  border: "1px solid #d1d5db",
+  padding: "0.6rem 1.2rem",
+  borderRadius: "0.5rem",
+  cursor: "pointer",
+  fontWeight: "500",
+};
+
+const botaoConfirmar = {
+  background: "#2563eb",
+  color: "#fff",
+  border: "none",
+  padding: "0.6rem 1.4rem",
+  borderRadius: "0.5rem",
+  cursor: "pointer",
+  fontWeight: "600",
+};

--- a/src/pages/ConsumoReposicao/ListaLotes.jsx
+++ b/src/pages/ConsumoReposicao/ListaLotes.jsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useState } from "react";
+import "../../styles/tabelaModerna.css";
+import "../../styles/botoes.css";
+
+export default function ListaLotes({ onAbrirCadastro }) {
+  const [lotes, setLotes] = useState([]);
+  const [colunaHover, setColunaHover] = useState(null);
+
+  const carregar = () => {
+    const dados = JSON.parse(localStorage.getItem("lotes") || "[]");
+    setLotes(dados);
+  };
+
+  useEffect(() => {
+    carregar();
+    window.addEventListener("lotesAtualizados", carregar);
+    return () => window.removeEventListener("lotesAtualizados", carregar);
+  }, []);
+
+  const numeroVacas = (lote) => {
+    const medicoes = JSON.parse(localStorage.getItem("medicoesLeite") || "[]");
+    const ultima = medicoes[medicoes.length - 1];
+    return ultima?.vacas?.filter((v) => v.lote === lote.nome).length || 0;
+  };
+
+  const alternarAtivo = (index) => {
+    const atualizados = [...lotes];
+    atualizados[index].ativo = !atualizados[index].ativo;
+    setLotes(atualizados);
+    localStorage.setItem("lotes", JSON.stringify(atualizados));
+    window.dispatchEvent(new Event("lotesAtualizados"));
+  };
+
+  const excluir = (index) => {
+    if (!window.confirm("Deseja excluir este lote?")) return;
+    const atualizados = lotes.filter((_, i) => i !== index);
+    setLotes(atualizados);
+    localStorage.setItem("lotes", JSON.stringify(atualizados));
+    window.dispatchEvent(new Event("lotesAtualizados"));
+  };
+
+  const titulos = ["Nome", "Nº de Vacas", "Função", "Status", "Ação"];
+
+  return (
+    <div className="w-full px-8 py-6 font-sans">
+      <div style={{ marginBottom: "10px" }}>
+        <button className="botao-acao" onClick={onAbrirCadastro}>
+          + Cadastrar Lote
+        </button>
+      </div>
+      <table className="tabela-padrao">
+        <thead>
+          <tr>
+            {titulos.map((titulo, idx) => (
+              <th
+                key={idx}
+                onMouseEnter={() => setColunaHover(idx)}
+                onMouseLeave={() => setColunaHover(null)}
+                className={colunaHover === idx ? "coluna-hover" : ""}
+              >
+                {titulo}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {lotes.length === 0 ? (
+            <tr>
+              <td colSpan={titulos.length} style={{ textAlign: "center" }}>
+                Nenhum lote cadastrado.
+              </td>
+            </tr>
+          ) : (
+            lotes.map((l, index) => (
+              <tr key={index}>
+                <td>{l.nome || "—"}</td>
+                <td>{numeroVacas(l)}</td>
+                <td>{l.funcao || "—"}</td>
+                <td>{l.ativo ? "Ativo" : "Inativo"}</td>
+                <td>
+                  <div style={{ display: "flex", gap: "0.4rem" }}>
+                    <button
+                      className="botao-editar"
+                      onClick={() => alternarAtivo(index)}
+                    >
+                      {l.ativo ? "Inativar" : "Ativar"}
+                    </button>
+                    <button
+                      className="botao-editar"
+                      onClick={() => excluir(index)}
+                      style={{ borderColor: "#dc3545", color: "#dc3545" }}
+                    >
+                      Excluir
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement modal form for registering lotes
- add dynamic lote table with activation and delete options

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420c7f769c8328b5b29117718f1892