### PR TITLE
Fix product save and filter by group

### DIFF
--- a/src/pages/ConsumoReposicao/CadastroProduto.jsx
+++ b/src/pages/ConsumoReposicao/CadastroProduto.jsx
@@ -210,13 +210,38 @@ export default function CadastroProduto({ onFechar, onSalvar }) {
       principioAtivo: listaPrincipios.join(", ")
     };
 
+    if (!atualizado.agrupamento && atualizado.categoria) {
+      let agrupamento = "";
+      if (["Ração", "Aditivos", "Suplementos"].includes(atualizado.categoria))
+        agrupamento = "Cozinha";
+      else if (
+        ["Detergentes", "Ácido", "Alcalino", "Sanitizante"].includes(
+          atualizado.categoria
+        )
+      )
+        agrupamento = "Higiene e Limpeza";
+      else if (
+        [
+          "Antibiótico",
+          "Antiparasitário",
+          "AINE",
+          "AIE",
+          "Hormônio",
+          "Vitaminas"
+        ].includes(atualizado.categoria)
+      )
+        agrupamento = "Farmácia";
+      else agrupamento = "Materiais Gerais";
+      atualizado.agrupamento = agrupamento;
+    }
+
     const produtosExistentes = JSON.parse(localStorage.getItem("produtos") || "[]");
     const atualizados = [...produtosExistentes, atualizado];
     localStorage.setItem("produtos", JSON.stringify(atualizados));
 
     alert("✅ Produto '" + produto.nomeComercial + "' cadastrado com sucesso!");
     window.dispatchEvent(new Event("produtosAtualizados"));
-    onSalvar();
+    onSalvar(atualizado);
   };
   return (
     <div style={overlay}>

--- a/src/pages/ConsumoReposicao/ListaProdutos.jsx
+++ b/src/pages/ConsumoReposicao/ListaProdutos.jsx
@@ -102,7 +102,12 @@ export default function ListaProdutos({ categoriaFiltro }) {
             produtos.map((p, index) => {
               if (!p) return null;
               const agrupamento = p.agrupamento || "";
-              if (categoriaFiltro !== "Todos" && agrupamento !== categoriaFiltro) return null;
+              if (
+                categoriaFiltro !== "Todos" &&
+                agrupamento &&
+                agrupamento !== categoriaFiltro
+              )
+                return null;
 
               const valorUnitario = calcularValorUnitario(p);
               const alertaEstoque = verificarAlertaEstoque(p);


### PR DESCRIPTION
## Summary
- ensure `CadastroProduto` sends the new product to the parent and computes `agrupamento` before saving
- relax `ListaProdutos` filtering when there is no grouping value

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68421e75d7e483288773f17fbab785a3