### PR TITLE
Implement sanitary calendar management

### DIFF
--- a/src/pages/ConsumoReposicao/CalendarioSanitario.jsx
+++ b/src/pages/ConsumoReposicao/CalendarioSanitario.jsx
@@ -1,10 +1,27 @@
-import React from "react";
+import React, { useState } from "react";
+import ListaCalendarioVacinal from "./ListaCalendarioVacinal";
+import ModalCadastroManejoSanitario from "./ModalCadastroManejoSanitario";
+import "../../styles/botoes.css";
 
 export default function CalendarioSanitario() {
+  const [mostrarModal, setMostrarModal] = useState(false);
+
   return (
     <div className="p-4">
-      <h3 className="text-lg font-bold text-blue-800 mb-4">📅 Calendário Sanitário</h3>
-      <p>Em breve: cronograma de vacinações, vermifugação, ferro e outros manejos.</p>
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-lg font-bold text-blue-800">Calendário Sanitário</h3>
+        <button className="botao-acao" onClick={() => setMostrarModal(true)}>
+          + Novo Manejo
+        </button>
+      </div>
+      <ListaCalendarioVacinal />
+      {mostrarModal && (
+        <ModalCadastroManejoSanitario
+          onFechar={() => setMostrarModal(false)}
+          onSalvar={() => setMostrarModal(false)}
+        />
+      )}
     </div>
   );
 }
+

--- a/src/pages/ConsumoReposicao/ListaCalendarioVacinal.jsx
+++ b/src/pages/ConsumoReposicao/ListaCalendarioVacinal.jsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useState } from "react";
+import ModalCadastroManejoSanitario from "./ModalCadastroManejoSanitario";
+import "../../styles/tabelaModerna.css";
+import "../../styles/botoes.css";
+
+export default function ListaCalendarioVacinal() {
+  const [manejos, setManejos] = useState([]);
+  const [editar, setEditar] = useState(null);
+  const [indiceEditar, setIndiceEditar] = useState(null);
+
+  useEffect(() => {
+    const carregar = () => {
+      const lista = JSON.parse(localStorage.getItem("manejosSanitarios") || "[]");
+      setManejos(lista);
+    };
+    carregar();
+    window.addEventListener("manejosSanitariosAtualizados", carregar);
+    return () => window.removeEventListener("manejosSanitariosAtualizados", carregar);
+  }, []);
+
+  const titulos = [
+    "Categoria", "Tipo", "Produto", "Frequência / Intervalo", "Idade de Aplicação",
+    "Via", "Dose (mL)", "Próxima Aplicação", "Ações"
+  ];
+
+  const fecharModal = () => {
+    setEditar(null);
+    setIndiceEditar(null);
+    const lista = JSON.parse(localStorage.getItem("manejosSanitarios") || "[]");
+    setManejos(lista);
+  };
+
+  return (
+    <div className="w-full">
+      <table className="tabela-padrao">
+        <thead>
+          <tr>
+            {titulos.map((t, i) => (
+              <th key={i}>{t}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {manejos.length === 0 ? (
+            <tr>
+              <td colSpan={titulos.length} style={{ textAlign: "center", padding: "20px" }}>
+                Nenhum manejo cadastrado.
+              </td>
+            </tr>
+          ) : (
+            manejos.map((m, idx) => (
+              <tr key={idx}>
+                <td>{m.categoria || "—"}</td>
+                <td>{m.tipo || "—"}</td>
+                <td>{m.produto || "—"}</td>
+                <td>{m.frequencia || "—"}</td>
+                <td>{m.idade || "—"}</td>
+                <td>{m.via || "—"}</td>
+                <td>{m.dose ? `${m.dose} mL` : "—"}</td>
+                <td>{m.dataInicial ? new Date(m.dataInicial).toLocaleDateString("pt-BR") : "—"}</td>
+                <td className="coluna-acoes">
+                  <div className="botoes-tabela">
+                    <button className="botao-editar" onClick={() => { setEditar(m); setIndiceEditar(idx); }}>
+                      Editar
+                    </button>
+                    <button
+                      className="botao-editar"
+                      style={{ borderColor: "#dc3545", color: "#dc3545" }}
+                      onClick={() => {
+                        if (window.confirm("Deseja excluir este manejo?")) {
+                          const nova = manejos.filter((_, i) => i !== idx);
+                          localStorage.setItem("manejosSanitarios", JSON.stringify(nova));
+                          setManejos(nova);
+                          window.dispatchEvent(new Event("manejosSanitariosAtualizados"));
+                        }
+                      }}
+                    >
+                      Excluir
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+
+      {editar && (
+        <ModalCadastroManejoSanitario
+          manejo={editar}
+          indice={indiceEditar}
+          onFechar={fecharModal}
+          onSalvar={fecharModal}
+        />
+      )}
+    </div>
+  );
+}
+

--- a/src/pages/ConsumoReposicao/ModalCadastroManejoSanitario.jsx
+++ b/src/pages/ConsumoReposicao/ModalCadastroManejoSanitario.jsx
@@ -1,0 +1,210 @@
+import React, { useEffect, useRef, useState } from "react";
+import Select from "react-select";
+
+export default function ModalCadastroManejoSanitario({ onFechar, onSalvar, manejo = null, indice = null }) {
+  const [dados, setDados] = useState({
+    categoria: manejo?.categoria || "",
+    tipo: manejo?.tipo || "",
+    produto: manejo?.produto || null,
+    frequencia: manejo?.frequencia || "",
+    idade: manejo?.idade || "",
+    via: manejo?.via || "",
+    dose: manejo?.dose || "",
+    dataInicial: manejo?.dataInicial || ""
+  });
+  const [produtos, setProdutos] = useState([]);
+  const refs = useRef([]);
+
+  useEffect(() => {
+    refs.current[0]?.focus();
+    const esc = (e) => e.key === "Escape" && onFechar?.();
+    window.addEventListener("keydown", esc);
+    const lista = JSON.parse(localStorage.getItem("produtos") || "[]");
+    const filtrados = lista.filter(p => p && p.agrupamento === "Farmácia");
+    setProdutos(filtrados.map(p => ({ value: p.nomeComercial, label: p.nomeComercial })));
+    return () => window.removeEventListener("keydown", esc);
+  }, [onFechar]);
+
+  const atualizar = (campo, valor) => setDados(prev => ({ ...prev, [campo]: valor }));
+
+  const salvar = () => {
+    if (!dados.categoria || !dados.tipo || !dados.produto || !dados.dose) {
+      alert("Preencha os campos obrigatórios.");
+      return;
+    }
+    const lista = JSON.parse(localStorage.getItem("manejosSanitarios") || "[]");
+    const registro = { ...dados };
+    if (indice != null) {
+      lista[indice] = registro;
+    } else {
+      lista.push(registro);
+    }
+    localStorage.setItem("manejosSanitarios", JSON.stringify(lista));
+    window.dispatchEvent(new Event("manejosSanitariosAtualizados"));
+    onSalvar?.(registro, indice);
+  };
+
+  const CATEGORIAS = ["Bezerra", "Novilha", "Vaca em lactação", "Vaca seca"];
+  const TIPOS = ["Vacina", "Vermífugo", "Vitamina", "Antiparasitário", "Preventivo"];
+  const VIAS = ["Subcutânea", "Oral", "Intramuscular"];
+
+  const input = () => ({
+    padding: "0.6rem",
+    border: "1px solid #ccc",
+    borderRadius: "0.5rem",
+    width: "100%",
+    fontSize: "0.95rem"
+  });
+
+  return (
+    <div style={overlay}>
+      <div style={modal}>
+        <div style={header}>+ Cadastro de Manejo Sanitário</div>
+        <div style={conteudo}>
+          <div>
+            <label>Categoria do Animal *</label>
+            <Select
+              options={CATEGORIAS.map(c => ({ value: c, label: c }))}
+              value={dados.categoria ? { value: dados.categoria, label: dados.categoria } : null}
+              onChange={op => atualizar("categoria", op?.value || "")}
+              className="react-select-container"
+              classNamePrefix="react-select"
+              placeholder="Selecione..."
+            />
+          </div>
+          <div>
+            <label>Tipo de Manejo *</label>
+            <Select
+              options={TIPOS.map(t => ({ value: t, label: t }))}
+              value={dados.tipo ? { value: dados.tipo, label: dados.tipo } : null}
+              onChange={op => atualizar("tipo", op?.value || "")}
+              className="react-select-container"
+              classNamePrefix="react-select"
+              placeholder="Selecione..."
+            />
+          </div>
+          <div>
+            <label>Produto / Princípio Ativo *</label>
+            <Select
+              options={produtos}
+              value={dados.produto ? { value: dados.produto, label: dados.produto } : null}
+              onChange={op => atualizar("produto", op?.value || null)}
+              className="react-select-container"
+              classNamePrefix="react-select"
+              placeholder="Selecione..."
+            />
+          </div>
+          <div>
+            <label>Frequência / Intervalo</label>
+            <input
+              value={dados.frequencia}
+              onChange={e => atualizar("frequencia", e.target.value)}
+              style={input()}
+            />
+          </div>
+          <div>
+            <label>Idade de Aplicação</label>
+            <input
+              value={dados.idade}
+              onChange={e => atualizar("idade", e.target.value)}
+              placeholder="Ex: 60 dias"
+              style={input()}
+            />
+          </div>
+          <div>
+            <label>Via de Administração</label>
+            <Select
+              options={VIAS.map(v => ({ value: v, label: v }))}
+              value={dados.via ? { value: dados.via, label: dados.via } : null}
+              onChange={op => atualizar("via", op?.value || "")}
+              className="react-select-container"
+              classNamePrefix="react-select"
+              placeholder="Selecione..."
+            />
+          </div>
+          <div>
+            <label>Dose por animal (mL) *</label>
+            <input
+              type="number"
+              value={dados.dose}
+              onChange={e => atualizar("dose", e.target.value)}
+              style={{ ...input(), width: "120px" }}
+            />
+          </div>
+          <div>
+            <label>Data Inicial</label>
+            <input
+              type="date"
+              value={dados.dataInicial}
+              onChange={e => atualizar("dataInicial", e.target.value)}
+              style={input()}
+            />
+          </div>
+          <div style={{ display: "flex", justifyContent: "flex-end", gap: "1rem", marginTop: "1rem" }}>
+            <button onClick={onFechar} style={botaoCancelar}>Cancelar</button>
+            <button onClick={salvar} style={botaoConfirmar}>Salvar</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const overlay = {
+  position: "fixed",
+  inset: 0,
+  backgroundColor: "rgba(0,0,0,0.6)",
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  zIndex: 9999
+};
+
+const modal = {
+  background: "#fff",
+  borderRadius: "1rem",
+  width: "480px",
+  maxHeight: "90vh",
+  overflowY: "auto",
+  fontFamily: "Poppins, sans-serif",
+  display: "flex",
+  flexDirection: "column"
+};
+
+const header = {
+  background: "#1e40af",
+  color: "white",
+  padding: "1rem 1.5rem",
+  fontWeight: "bold",
+  fontSize: "1.1rem",
+  borderTopLeftRadius: "1rem",
+  borderTopRightRadius: "1rem",
+  textAlign: "center"
+};
+
+const conteudo = {
+  padding: "1.5rem",
+  display: "flex",
+  flexDirection: "column",
+  gap: "1rem"
+};
+
+const botaoCancelar = {
+  background: "#f3f4f6",
+  border: "1px solid #d1d5db",
+  padding: "0.6rem 1.2rem",
+  borderRadius: "0.5rem",
+  cursor: "pointer",
+  fontWeight: "500"
+};
+
+const botaoConfirmar = {
+  background: "#2563eb",
+  color: "#fff",
+  border: "none",
+  padding: "0.6rem 1.4rem",
+  borderRadius: "0.5rem",
+  cursor: "pointer",
+  fontWeight: "600"
+};
+


### PR DESCRIPTION
## Summary
- add `ListaCalendarioVacinal` table for sanitary events
- add modal `ModalCadastroManejoSanitario` to register vaccines and treatments
- update `CalendarioSanitario` page to display table and handle new entries

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844236871888328bcdb7ae6123a888a