### PR TITLE
Add sanitary management modals

### DIFF
--- a/src/pages/ConsumoReposicao/CalendarioSanitario.jsx
+++ b/src/pages/ConsumoReposicao/CalendarioSanitario.jsx
@@ -1,18 +1,25 @@
 import React, { useState } from "react";
 import ListaCalendarioVacinal from "./ListaCalendarioVacinal";
 import ModalCadastroManejoSanitario from "./ModalCadastroManejoSanitario";
+import ModalExamesSanitarios from "./ModalExamesSanitarios";
 import "../../styles/botoes.css";
 
 export default function CalendarioSanitario() {
   const [mostrarModal, setMostrarModal] = useState(false);
+  const [mostrarExames, setMostrarExames] = useState(false);
 
   return (
     <div className="p-4">
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-lg font-bold text-blue-800">Calendário Sanitário</h3>
-        <button className="botao-acao" onClick={() => setMostrarModal(true)}>
-          + Novo Manejo
-        </button>
+        <div className="flex gap-2">
+          <button className="botao-acao" onClick={() => setMostrarExames(true)}>
+            Exames Sanitários
+          </button>
+          <button className="botao-acao" onClick={() => setMostrarModal(true)}>
+            + Novo Manejo
+          </button>
+        </div>
       </div>
       <ListaCalendarioVacinal />
       {mostrarModal && (
@@ -20,6 +27,9 @@ export default function CalendarioSanitario() {
           onFechar={() => setMostrarModal(false)}
           onSalvar={() => setMostrarModal(false)}
         />
+      )}
+      {mostrarExames && (
+        <ModalExamesSanitarios onFechar={() => setMostrarExames(false)} />
       )}
     </div>
   );

--- a/src/pages/ConsumoReposicao/ListaCalendarioVacinal.jsx
+++ b/src/pages/ConsumoReposicao/ListaCalendarioVacinal.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import ModalCadastroManejoSanitario from "./ModalCadastroManejoSanitario";
+import ModalRegistroAplicacao from "./ModalRegistroAplicacao";
 import "../../styles/tabelaModerna.css";
 import "../../styles/botoes.css";
 
@@ -7,6 +8,8 @@ export default function ListaCalendarioVacinal() {
   const [manejos, setManejos] = useState([]);
   const [editar, setEditar] = useState(null);
   const [indiceEditar, setIndiceEditar] = useState(null);
+  const [registrar, setRegistrar] = useState(null);
+  const [indiceRegistrar, setIndiceRegistrar] = useState(null);
 
   useEffect(() => {
     const carregar = () => {
@@ -26,6 +29,13 @@ export default function ListaCalendarioVacinal() {
   const fecharModal = () => {
     setEditar(null);
     setIndiceEditar(null);
+    const lista = JSON.parse(localStorage.getItem("manejosSanitarios") || "[]");
+    setManejos(lista);
+  };
+
+  const fecharRegistro = () => {
+    setRegistrar(null);
+    setIndiceRegistrar(null);
     const lista = JSON.parse(localStorage.getItem("manejosSanitarios") || "[]");
     setManejos(lista);
   };
@@ -57,11 +67,14 @@ export default function ListaCalendarioVacinal() {
                 <td>{m.idade || "—"}</td>
                 <td>{m.via || "—"}</td>
                 <td>{m.dose ? `${m.dose} mL` : "—"}</td>
-                <td>{m.dataInicial ? new Date(m.dataInicial).toLocaleDateString("pt-BR") : "—"}</td>
+                <td>{m.proximaAplicacao ? new Date(m.proximaAplicacao).toLocaleDateString("pt-BR") : (m.dataInicial ? new Date(m.dataInicial).toLocaleDateString("pt-BR") : "—")}</td>
                 <td className="coluna-acoes">
                   <div className="botoes-tabela">
                     <button className="botao-editar" onClick={() => { setEditar(m); setIndiceEditar(idx); }}>
                       Editar
+                    </button>
+                    <button className="botao-editar" onClick={() => { setRegistrar(m); setIndiceRegistrar(idx); }}>
+                      Registrar
                     </button>
                     <button
                       className="botao-editar"
@@ -91,6 +104,13 @@ export default function ListaCalendarioVacinal() {
           indice={indiceEditar}
           onFechar={fecharModal}
           onSalvar={fecharModal}
+        />
+      )}
+      {registrar && (
+        <ModalRegistroAplicacao
+          manejo={registrar}
+          indice={indiceRegistrar}
+          onFechar={fecharRegistro}
         />
       )}
     </div>

--- a/src/pages/ConsumoReposicao/ModalCadastroManejoSanitario.jsx
+++ b/src/pages/ConsumoReposicao/ModalCadastroManejoSanitario.jsx
@@ -34,6 +34,16 @@ export default function ModalCadastroManejoSanitario({ onFechar, onSalvar, manej
     }
     const lista = JSON.parse(localStorage.getItem("manejosSanitarios") || "[]");
     const registro = { ...dados };
+    if (dados.dataInicial) {
+      const dias = parseInt(dados.frequencia);
+      if (!isNaN(dias)) {
+        const d = new Date(dados.dataInicial);
+        d.setDate(d.getDate() + dias);
+        registro.proximaAplicacao = d.toISOString().substring(0, 10);
+      } else {
+        registro.proximaAplicacao = dados.dataInicial;
+      }
+    }
     if (indice != null) {
       lista[indice] = registro;
     } else {
@@ -44,7 +54,7 @@ export default function ModalCadastroManejoSanitario({ onFechar, onSalvar, manej
     onSalvar?.(registro, indice);
   };
 
-  const CATEGORIAS = ["Bezerra", "Novilha", "Vaca em lactação", "Vaca seca"];
+  const CATEGORIAS = ["Bezerra", "Novilha", "Vaca em lactação", "Vaca seca", "Todo plantel"];
   const TIPOS = ["Vacina", "Vermífugo", "Vitamina", "Antiparasitário", "Preventivo"];
   const VIAS = ["Subcutânea", "Oral", "Intramuscular"];
 

--- a/src/pages/ConsumoReposicao/ModalExamesSanitarios.jsx
+++ b/src/pages/ConsumoReposicao/ModalExamesSanitarios.jsx
@@ -1,0 +1,129 @@
+import React, { useEffect, useState } from "react";
+
+export default function ModalExamesSanitarios({ onFechar }) {
+  const [dados, setDados] = useState({
+    nome: "",
+    status: "nao",
+    dataUltimo: "",
+    comprovante: null,
+    exameEntrada: false,
+  });
+
+  useEffect(() => {
+    const esc = (e) => e.key === "Escape" && onFechar?.();
+    window.addEventListener("keydown", esc);
+    return () => window.removeEventListener("keydown", esc);
+  }, [onFechar]);
+
+  const atualizar = (campo, valor) => setDados((p) => ({ ...p, [campo]: valor }));
+
+  const salvar = () => {
+    const lista = JSON.parse(localStorage.getItem("examesSanitarios") || "[]");
+    lista.push(dados);
+    localStorage.setItem("examesSanitarios", JSON.stringify(lista));
+    onFechar?.();
+  };
+
+  const input = () => ({
+    padding: "0.6rem",
+    border: "1px solid #ccc",
+    borderRadius: "0.5rem",
+    width: "100%",
+    fontSize: "0.95rem",
+  });
+
+  return (
+    <div style={overlay}>
+      <div style={modal}>
+        <div style={header}>Controle de Exames</div>
+        <div style={conteudo}>
+          <div>
+            <label>Nome do Exame</label>
+            <input value={dados.nome} onChange={e => atualizar("nome", e.target.value)} style={input()} />
+          </div>
+          <div>
+            <label>Status da Propriedade</label>
+            <select value={dados.status} onChange={e => atualizar("status", e.target.value)} style={input()}>
+              <option value="nao">Não certificada</option>
+              <option value="sim">Certificada</option>
+            </select>
+          </div>
+          <div>
+            <label>Data do Último Exame</label>
+            <input type="date" value={dados.dataUltimo} onChange={e => atualizar("dataUltimo", e.target.value)} style={input()} />
+          </div>
+          <div>
+            <label>Comprovante</label>
+            <input type="file" onChange={e => atualizar("comprovante", e.target.files[0])} style={input()} />
+          </div>
+          <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+            <input type="checkbox" checked={dados.exameEntrada} onChange={e => atualizar("exameEntrada", e.target.checked)} />
+            <span>Exame de entrada para animal novo?</span>
+          </div>
+          <div style={{ display: "flex", justifyContent: "flex-end", gap: "1rem", marginTop: "1rem" }}>
+            <button onClick={onFechar} style={botaoCancelar}>Cancelar</button>
+            <button onClick={salvar} style={botaoConfirmar}>Salvar</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const overlay = {
+  position: "fixed",
+  inset: 0,
+  backgroundColor: "rgba(0,0,0,0.6)",
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  zIndex: 9999,
+};
+
+const modal = {
+  background: "#fff",
+  borderRadius: "1rem",
+  width: "480px",
+  maxHeight: "90vh",
+  overflowY: "auto",
+  fontFamily: "Poppins, sans-serif",
+  display: "flex",
+  flexDirection: "column",
+};
+
+const header = {
+  background: "#1e40af",
+  color: "white",
+  padding: "1rem 1.5rem",
+  fontWeight: "bold",
+  fontSize: "1.1rem",
+  borderTopLeftRadius: "1rem",
+  borderTopRightRadius: "1rem",
+  textAlign: "center",
+};
+
+const conteudo = {
+  padding: "1.5rem",
+  display: "flex",
+  flexDirection: "column",
+  gap: "1rem",
+};
+
+const botaoCancelar = {
+  background: "#f3f4f6",
+  border: "1px solid #d1d5db",
+  padding: "0.6rem 1.2rem",
+  borderRadius: "0.5rem",
+  cursor: "pointer",
+  fontWeight: "500",
+};
+
+const botaoConfirmar = {
+  background: "#2563eb",
+  color: "#fff",
+  border: "none",
+  padding: "0.6rem 1.4rem",
+  borderRadius: "0.5rem",
+  cursor: "pointer",
+  fontWeight: "600",
+};

--- a/src/pages/ConsumoReposicao/ModalRegistroAplicacao.jsx
+++ b/src/pages/ConsumoReposicao/ModalRegistroAplicacao.jsx
@@ -1,0 +1,122 @@
+import React, { useEffect, useState } from "react";
+
+export default function ModalRegistroAplicacao({ manejo, indice, onFechar }) {
+  const [data, setData] = useState(() => {
+    const hoje = new Date();
+    return hoje.toISOString().substring(0, 10);
+  });
+  const [observacoes, setObservacoes] = useState("");
+
+  useEffect(() => {
+    const esc = (e) => e.key === "Escape" && onFechar?.();
+    window.addEventListener("keydown", esc);
+    return () => window.removeEventListener("keydown", esc);
+  }, [onFechar]);
+
+  const salvar = () => {
+    const lista = JSON.parse(localStorage.getItem("manejosSanitarios") || "[]");
+    if (indice != null && lista[indice]) {
+      const registro = lista[indice];
+      registro.ultimaAplicacao = data;
+      registro.observacoes = observacoes;
+      const dias = parseInt(registro.frequencia);
+      if (!isNaN(dias)) {
+        const d = new Date(data);
+        d.setDate(d.getDate() + dias);
+        registro.proximaAplicacao = d.toISOString().substring(0, 10);
+      }
+      lista[indice] = registro;
+      localStorage.setItem("manejosSanitarios", JSON.stringify(lista));
+      window.dispatchEvent(new Event("manejosSanitariosAtualizados"));
+    }
+    onFechar?.();
+  };
+
+  const input = () => ({
+    padding: "0.6rem",
+    border: "1px solid #ccc",
+    borderRadius: "0.5rem",
+    width: "100%",
+    fontSize: "0.95rem",
+  });
+
+  return (
+    <div style={overlay}>
+      <div style={modal}>
+        <div style={header}>Registrar Aplicação</div>
+        <div style={conteudo}>
+          <div>
+            <label>Data da Aplicação</label>
+            <input type="date" value={data} onChange={e => setData(e.target.value)} style={input()} />
+          </div>
+          <div>
+            <label>Observações</label>
+            <textarea value={observacoes} onChange={e => setObservacoes(e.target.value)} style={{...input(), height: "80px"}} />
+          </div>
+          <div style={{ display: "flex", justifyContent: "flex-end", gap: "1rem", marginTop: "1rem" }}>
+            <button onClick={onFechar} style={botaoCancelar}>Cancelar</button>
+            <button onClick={salvar} style={botaoConfirmar}>Salvar</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const overlay = {
+  position: "fixed",
+  inset: 0,
+  backgroundColor: "rgba(0,0,0,0.6)",
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  zIndex: 9999,
+};
+
+const modal = {
+  background: "#fff",
+  borderRadius: "1rem",
+  width: "420px",
+  maxHeight: "90vh",
+  overflowY: "auto",
+  fontFamily: "Poppins, sans-serif",
+  display: "flex",
+  flexDirection: "column",
+};
+
+const header = {
+  background: "#1e40af",
+  color: "white",
+  padding: "1rem 1.5rem",
+  fontWeight: "bold",
+  fontSize: "1.1rem",
+  borderTopLeftRadius: "1rem",
+  borderTopRightRadius: "1rem",
+  textAlign: "center",
+};
+
+const conteudo = {
+  padding: "1.5rem",
+  display: "flex",
+  flexDirection: "column",
+  gap: "1rem",
+};
+
+const botaoCancelar = {
+  background: "#f3f4f6",
+  border: "1px solid #d1d5db",
+  padding: "0.6rem 1.2rem",
+  borderRadius: "0.5rem",
+  cursor: "pointer",
+  fontWeight: "500",
+};
+
+const botaoConfirmar = {
+  background: "#2563eb",
+  color: "#fff",
+  border: "none",
+  padding: "0.6rem 1.4rem",
+  borderRadius: "0.5rem",
+  cursor: "pointer",
+  fontWeight: "600",
+};


### PR DESCRIPTION
## Summary
- add 'Registrar Aplicação' modal to log applications
- add modal for sanitary exams
- integrate new modals in calendar pages
- compute next application date when saving sanitary management

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684426ca97248328923e8aaad43c673e