### PR TITLE
Melhorias visuais em ciclos de limpeza

### DIFF
--- a/src/pages/ConsumoReposicao/ListaLimpeza.jsx
+++ b/src/pages/ConsumoReposicao/ListaLimpeza.jsx
@@ -269,25 +269,75 @@ export default function ListaLimpeza({ onEditar }) {
                     </button>
                     <button
                       className="botao-editar"
-                      onClick={() => setPlanoAtivo(planoAtivo === index ? null : index)}
+                      onClick={() => setPlanoAtivo(index)}
                       style={{ borderColor: "#6b7280", color: "#6b7280" }}
                     >
-                      {planoAtivo === index ? "Fechar" : "Ver plano"}
+                      Ver plano
                     </button>
                   </div>
                 </td>
               </tr>
-              {planoAtivo === index && (
-                <tr>
-                  <td colSpan={titulos.length}>
-                    <pre style={{ whiteSpace: "pre-wrap" }}>{detalharPlano(c)}</pre>
-                  </td>
-                </tr>
-              )}
             </React.Fragment>
           ))
         )}
       </tbody>
     </table>
+    {planoAtivo !== null && (
+      <div style={overlay} onClick={() => setPlanoAtivo(null)}>
+        <div style={modal} onClick={(e) => e.stopPropagation()}>
+          <div style={header}>Plano de Limpeza</div>
+          <div style={{ padding: "1rem" }}>
+            <pre style={{ whiteSpace: "pre-wrap" }}>{detalharPlano(ciclos[planoAtivo])}</pre>
+          </div>
+          <div style={{ textAlign: "right", padding: "0 1rem 1rem" }}>
+            <button onClick={() => setPlanoAtivo(null)} style={botaoConfirmar}>
+              Fechar
+            </button>
+          </div>
+        </div>
+      </div>
+    )}
   );
 }
+
+const overlay = {
+  position: "fixed",
+  inset: 0,
+  backgroundColor: "rgba(0,0,0,0.6)",
+  display: "flex",
+  justifyContent: "center",
+  alignItems: "center",
+  zIndex: 9999,
+};
+
+const modal = {
+  background: "#fff",
+  borderRadius: "1rem",
+  width: "600px",
+  maxHeight: "90vh",
+  overflowY: "auto",
+  fontFamily: "Poppins, sans-serif",
+  display: "flex",
+  flexDirection: "column",
+};
+
+const header = {
+  background: "#1e40af",
+  color: "white",
+  padding: "1rem 1.5rem",
+  fontWeight: "bold",
+  fontSize: "1.1rem",
+  borderTopLeftRadius: "1rem",
+  borderTopRightRadius: "1rem",
+  textAlign: "center",
+};
+
+const botaoConfirmar = {
+  background: "#2563eb",
+  color: "#fff",
+  border: "none",
+  padding: "0.6rem 1.4rem",
+  borderRadius: "0.5rem",
+  cursor: "pointer",
+  fontWeight: "600",
+};

--- a/src/pages/ConsumoReposicao/ModalCadastroCiclo.jsx
+++ b/src/pages/ConsumoReposicao/ModalCadastroCiclo.jsx
@@ -167,22 +167,19 @@ export default function ModalCadastroCiclo({ onFechar, onSalvar, ciclo = null, i
                     placeholder="Selecione..."
                   />
                 </div>
-                <div style={{ marginBottom: "0.5rem", display: "flex", gap: "8px" }}>
-                  <div style={{ flex: 1 }}>
-                    <label>Quantidade *</label>
+                <div style={{ marginBottom: "0.5rem" }}>
+                  <label>Quantidade *</label>
+                  <div style={{ display: "flex", gap: "8px", alignItems: "center" }}>
                     <input
                       type="number"
                       value={e.quantidade}
                       onChange={ev => atualizarEtapa(idx, "quantidade", ev.target.value)}
-                      style={{ ...input(), width: "100%" }}
+                      style={{ ...input(), flex: 1 }}
                     />
-                  </div>
-                  <div style={{ width: "110px" }}>
-                    <label>Unidade</label>
                     <select
                       value={e.unidade}
                       onChange={ev => atualizarEtapa(idx, "unidade", ev.target.value)}
-                      style={input()}
+                      style={{ ...input(), width: "110px" }}
                     >
                       <option value="mL">mL</option>
                       <option value="litros">litros</option>


### PR DESCRIPTION
## Summary
- ajustar visual do preenchimento de quantidade/unidade no cadastro de ciclo
- mostrar plano de limpeza em modal na lista de ciclos

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684476d543048328929615cde8528067