### PR TITLE
Add complementary step option

### DIFF
--- a/src/pages/ConsumoReposicao/ListaLimpeza.jsx
+++ b/src/pages/ConsumoReposicao/ListaLimpeza.jsx
@@ -172,6 +172,7 @@ export default function ListaLimpeza({ onEditar }) {
       for (let exec = 0; exec < freq; exec++) {
         const horario = freq === 1 ? "" : exec === 0 ? "Manhã" : exec === 1 ? "Tarde" : `Ordenha ${exec + 1}`;
         let itens = [];
+        let ultimaCondBase = null;
         etapas.forEach((e, i) => {
           cont[i] += 1;
           const cond = parseCond(e.condicao);
@@ -182,7 +183,14 @@ export default function ListaLimpeza({ onEditar }) {
           if (aplicar) {
             let texto = `${e.quantidade} ${e.unidade} ${e.produto}`;
             if (cond.tipo === "cada") texto += ` (condicional: ${cond.intervalo}ª ordenha)`;
-            itens.push(texto);
+            if (e.complementar && ultimaCondBase &&
+                cond.tipo === ultimaCondBase.tipo &&
+                (cond.intervalo || 0) === (ultimaCondBase.intervalo || 0)) {
+              itens.push(texto);
+            } else {
+              itens.push(texto);
+              if (!e.complementar) ultimaCondBase = cond;
+            }
           }
         });
         if (itens.length) partes.push(`- ${horario || `Ordenha ${exec + 1}`}: ${itens.join(" + ")}`);

--- a/src/pages/ConsumoReposicao/ModalCadastroCiclo.jsx
+++ b/src/pages/ConsumoReposicao/ModalCadastroCiclo.jsx
@@ -32,7 +32,8 @@ export default function ModalCadastroCiclo({ onFechar, onSalvar, ciclo = null, i
           quantidade: e.quantidade || "",
           unidade: e.unidade || "mL",
           condicaoTipo: tipo,
-          intervalo: intervalo
+          intervalo: intervalo,
+          complementar: !!e.complementar
         };
       });
     }
@@ -43,12 +44,13 @@ export default function ModalCadastroCiclo({ onFechar, onSalvar, ciclo = null, i
           quantidade: ciclo.quantidade || "",
           unidade: ciclo.unidade || "mL",
           condicaoTipo: "sempre",
-          intervalo: ""
+          intervalo: "",
+          complementar: false
         }
       ];
     }
     return [
-      { produto: null, quantidade: "", unidade: "mL", condicaoTipo: "sempre", intervalo: "" }
+      { produto: null, quantidade: "", unidade: "mL", condicaoTipo: "sempre", intervalo: "", complementar: false }
     ];
   });
   const [produtos, setProdutos] = useState([]);
@@ -74,7 +76,7 @@ export default function ModalCadastroCiclo({ onFechar, onSalvar, ciclo = null, i
   const adicionarEtapa = () => {
     setEtapas((prev) => [
       ...prev,
-      { produto: null, quantidade: "", unidade: "mL", condicaoTipo: "sempre", intervalo: "" }
+      { produto: null, quantidade: "", unidade: "mL", condicaoTipo: "sempre", intervalo: "", complementar: false }
     ]);
   };
 
@@ -105,7 +107,8 @@ export default function ModalCadastroCiclo({ onFechar, onSalvar, ciclo = null, i
           produto: e.produto,
           quantidade: parseFloat(e.quantidade),
           unidade: e.unidade,
-          condicao: cond
+          condicao: cond,
+          complementar: !!e.complementar
         };
       })
     };
@@ -211,6 +214,16 @@ export default function ModalCadastroCiclo({ onFechar, onSalvar, ciclo = null, i
                       </>
                     )}
                   </div>
+                </div>
+                <div style={{ marginBottom: "0.5rem" }}>
+                  <label style={{ display: "flex", alignItems: "center", gap: "0.4rem" }}>
+                    <input
+                      type="checkbox"
+                      checked={!!e.complementar}
+                      onChange={ev => atualizarEtapa(idx, "complementar", ev.target.checked)}
+                    />
+                    <span>Esta etapa é complementar (aplicada após outro produto na mesma ordenha)</span>
+                  </label>
                 </div>
                 {etapas.length > 1 && (
                   <button

--- a/src/pages/ConsumoReposicao/ModalPlanoCiclo.jsx
+++ b/src/pages/ConsumoReposicao/ModalPlanoCiclo.jsx
@@ -80,6 +80,7 @@ export default function ModalPlanoCiclo({ ciclo, onClose }) {
     for (let exec = 0; exec < freq; exec++) {
       const horario = freq === 1 ? "" : exec === 0 ? "Manhã" : exec === 1 ? "Tarde" : `Ordenha ${exec + 1}`;
       const itens = [];
+      let ultimaCondBase = null;
       etapas.forEach((e, i) => {
         cont[i] += 1;
         const cond = parseCond(e.condicao);
@@ -90,7 +91,14 @@ export default function ModalPlanoCiclo({ ciclo, onClose }) {
         if (aplicar) {
           let texto = `${e.quantidade} ${e.unidade} ${e.produto}`;
           if (cond.tipo === "cada") texto += ` (condicional: ${cond.intervalo}ª ordenha)`;
-          itens.push(texto);
+          if (e.complementar && ultimaCondBase &&
+              cond.tipo === ultimaCondBase.tipo &&
+              (cond.intervalo || 0) === (ultimaCondBase.intervalo || 0)) {
+            itens.push(texto);
+          } else {
+            itens.push(texto);
+            if (!e.complementar) ultimaCondBase = cond;
+          }
         }
       });
       if (itens.length) execs.push({ horario, itens });


### PR DESCRIPTION
## Summary
- allow marking washing steps as complementary in `ModalCadastroCiclo`
- show checkbox for complementary step
- display complementary items together in `ModalPlanoCiclo`
- include complementary items when detailing plans in `ListaLimpeza`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bab278f48328b06043c3349f5062