### PR TITLE
Corrigir cálculo de custo diário

### DIFF
--- a/src/pages/ConsumoReposicao/CadastroProduto.jsx
+++ b/src/pages/ConsumoReposicao/CadastroProduto.jsx
@@ -118,6 +118,7 @@ export default function CadastroProduto({ onFechar, onSalvar }) {
     quantidade: "",
     apresentacao: "",
     volume: "",
+    volumeUnidade: "mL",
     validade: "",
     analogo: "",
     agrupamento: "",
@@ -526,14 +527,24 @@ export default function CadastroProduto({ onFechar, onSalvar }) {
             )}
             {["Antibiótico", "Antiparasitário", "Hormônio", "AINE", "Vitaminas"].includes(produto.categoria) && (
               <div>
-                <label>Volume (mL ou L)</label>
-                <input
-                  type="number"
-                  value={produto.volume || ""}
-                  onChange={(e) => atualizarCampo("volume", e.target.value)}
-                  style={input()}
-                  placeholder="Ex: 50"
-                />
+                <label>Volume</label>
+                <div style={{ display: "flex", gap: "0.5rem" }}>
+                  <input
+                    type="number"
+                    value={produto.volume || ""}
+                    onChange={(e) => atualizarCampo("volume", e.target.value)}
+                    style={{ ...input(), flex: 1 }}
+                    placeholder="Ex: 50"
+                  />
+                  <select
+                    value={produto.volumeUnidade}
+                    onChange={(e) => atualizarCampo("volumeUnidade", e.target.value)}
+                    style={{ ...input(), width: "90px" }}
+                  >
+                    <option value="mL">mL</option>
+                    <option value="litros">litros</option>
+                  </select>
+                </div>
               </div>
             )}
 

--- a/src/pages/ConsumoReposicao/Estoque.jsx
+++ b/src/pages/ConsumoReposicao/Estoque.jsx
@@ -47,7 +47,11 @@ export default function Estoque() {
   const calcularValorUnitario = (produto) => {
     if (!produto) return null;
     if (produto.valorTotal && produto.quantidade && produto.volume) {
-      const totalVolume = produto.quantidade * produto.volume;
+      let vol = parseFloat(produto.volume);
+      if (produto.volumeUnidade && produto.volumeUnidade.toLowerCase().includes("l")) {
+        vol *= 1000;
+      }
+      const totalVolume = produto.quantidade * vol;
       return totalVolume > 0 ? produto.valorTotal / totalVolume : null;
     }
     return null;
@@ -134,7 +138,7 @@ export default function Estoque() {
                   <td>{p.quantidade ? `${p.quantidade} ${p.unidade || ""}` : "—"}</td>
                   <td>{p.valorTotal ? `R$ ${Number(p.valorTotal).toFixed(2)}` : "—"}</td>
                   <td>{p.apresentacao || "—"}</td>
-                  <td>{p.volume ? `${p.volume} ${p.unidade || ""}` : "—"}</td>
+                  <td>{p.volume ? `${p.volume} ${p.volumeUnidade || ""}` : "—"}</td>
                   <td>{valorUnitario ? `R$ ${valorUnitario.toFixed(2)} / ${p.unidade}` : "—"}</td>
                   <td>{p.validade || "—"}</td>
                   <td style={{ color: alertaEstoque ? "red" : "green", fontWeight: 600 }}>

--- a/src/pages/ConsumoReposicao/ListaLimpeza.jsx
+++ b/src/pages/ConsumoReposicao/ListaLimpeza.jsx
@@ -100,7 +100,7 @@ export default function ListaLimpeza({ onEditar }) {
             const idx = produtos.findIndex((p) => p.nomeComercial === e.produto);
             if (idx === -1) return;
             const prod = produtos[idx];
-            const volumeUnidade = convToMl(prod.volume || 0, prod.unidade);
+            const volumeUnidade = convToMl(prod.volume || 0, prod.volumeUnidade || prod.unidade);
             let totalMl = volumeUnidade * parseFloat(prod.quantidade || 0);
             const consumoMl = convToMl(e.quantidade, e.unidade);
             totalMl = Math.max(0, totalMl - consumoMl);
@@ -134,7 +134,7 @@ export default function ListaLimpeza({ onEditar }) {
     Object.entries(consumo).forEach(([nome, cons]) => {
       const prod = produtos.find((p) => p.nomeComercial === nome);
       if (!prod) return;
-      const estoque = convToMl(prod.volume || 0, prod.unidade) * parseFloat(prod.quantidade || 0);
+      const estoque = convToMl(prod.volume || 0, prod.volumeUnidade || prod.unidade) * parseFloat(prod.quantidade || 0);
       if (cons > 0) dias = Math.min(dias, estoque / cons);
     });
     if (!isFinite(dias) || dias === Infinity) return "—";
@@ -145,26 +145,26 @@ export default function ListaLimpeza({ onEditar }) {
     const produtos = JSON.parse(localStorage.getItem("produtos") || "[]");
     const freq = parseInt(c.frequencia || 1);
     const etapas = c.etapas || [
-      { produto: c.produto, quantidade: c.quantidade, unidade: c.unidade, condicao: { tipo: "sempre" } }
+      { produto: c.produto, quantidade: c.quantidade, unidade: c.unidade }
     ];
-    let custoTotal = 0;
+    let total = 0;
     etapas.forEach((etapa) => {
-      if (!etapa || !etapa.produto) return;
-      const produto = produtos.find((p) => p.nomeComercial === etapa.produto);
-      if (!produto) return;
+      const prod = produtos.find((p) => p.nomeComercial === etapa.produto);
+      if (!prod) return;
 
-      const volumeUnidade = convToMl(produto.volume || 0, produto.unidade);
-      const volumeTotalMl = volumeUnidade * parseFloat(produto.quantidade || 0);
-      const valorTotal = parseFloat(produto.valorTotal || 0);
-      const precoPorML = volumeTotalMl > 0 ? valorTotal / volumeTotalMl : 0;
+      let vol = parseFloat(prod.volume);
+      if (prod.volumeUnidade && prod.volumeUnidade.toLowerCase().includes("l")) {
+        vol *= 1000;
+      }
+      const precoPorML = vol > 0 ? parseFloat(prod.valorTotal || 0) / vol : 0;
+      console.log("Cálculo custo", prod.nomeComercial, "volML", vol, "preço/ML", precoPorML);
 
-      const vezesDia = vezesPorDia(parseCond(etapa.condicao), freq);
       const usoPorAplicacao = convToMl(etapa.quantidade, etapa.unidade);
-      const custoEtapa = usoPorAplicacao * precoPorML * vezesDia;
-      custoTotal += custoEtapa;
+      const consumoPorDia = usoPorAplicacao * freq;
+      total += consumoPorDia * precoPorML;
     });
 
-    return custoTotal > 0 ? `R$ ${custoTotal.toFixed(2)}` : "—";
+    return total > 0 ? `R$ ${total.toFixed(2)}` : "—";
   };
 
   const detalharPlano = (c) => {

--- a/src/pages/ConsumoReposicao/ListaProdutos.jsx
+++ b/src/pages/ConsumoReposicao/ListaProdutos.jsx
@@ -38,7 +38,11 @@ export default function ListaProdutos({ categoriaFiltro }) {
 
   const calcularValorUnitario = (produto) => {
     if (produto.valorTotal && produto.quantidade && produto.volume) {
-      const totalVolume = produto.quantidade * produto.volume;
+      let vol = parseFloat(produto.volume);
+      if (produto.volumeUnidade && produto.volumeUnidade.toLowerCase().includes("l")) {
+        vol *= 1000;
+      }
+      const totalVolume = produto.quantidade * vol;
       return totalVolume > 0 ? produto.valorTotal / totalVolume : null;
     }
     return null;
@@ -120,7 +124,7 @@ export default function ListaProdutos({ categoriaFiltro }) {
                   <td>{p.quantidade ? `${p.quantidade} ${p.unidade || ""}` : "—"}</td>
                   <td>{p.valorTotal ? `R$ ${Number(p.valorTotal).toFixed(2)}` : "—"}</td>
                   <td>{p.apresentacao || "—"}</td>
-                  <td>{p.volume ? `${p.volume} ${p.unidade || ""}` : "—"}</td>
+                  <td>{p.volume ? `${p.volume} ${p.volumeUnidade || ""}` : "—"}</td>
                   <td>{valorUnitario ? `R$ ${valorUnitario.toFixed(2)} / ${p.unidade}` : "—"}</td>
                   <td>{p.validade || "—"}</td>
                   <td style={{ color: alertaEstoque ? "red" : "green", fontWeight: 600 }}>

--- a/src/pages/ConsumoReposicao/ModalEditarProduto.jsx
+++ b/src/pages/ConsumoReposicao/ModalEditarProduto.jsx
@@ -190,24 +190,60 @@ o01rv-codex/criar-aba-de-estoque
             )}
           </div>
 
-          {[
-            ["Quantidade", "quantidade", "number"],
-            ["Volume", "volume", "number"],
-            ["Valor Total", "valorTotal", "number"],
-            ["Validade", "validade", "date"],
-          ].map(([label, campo, tipo], i) => (
-            <div key={campo} style={estilos.campo}>
-              <label>{label}</label>
+          <div style={estilos.campo}>
+            <label>Quantidade</label>
+            <input
+              ref={(el) => (camposRef.current[1] = el)}
+              type="number"
+              value={editado.quantidade || ""}
+              onChange={(e) => atualizar("quantidade", e.target.value)}
+              onKeyDown={(e) => handleKeyDown(e, 1)}
+              style={estilos.input}
+            />
+          </div>
+          <div style={estilos.campo}>
+            <label>Volume</label>
+            <div style={{ display: "flex", gap: "0.5rem" }}>
               <input
-                ref={(el) => (camposRef.current[i + 1] = el)}
-                type={tipo}
-                value={editado[campo] || ""}
-                onChange={(e) => atualizar(campo, e.target.value)}
-                onKeyDown={(e) => handleKeyDown(e, i + 1)}
-                style={estilos.input}
+                ref={(el) => (camposRef.current[2] = el)}
+                type="number"
+                value={editado.volume || ""}
+                onChange={(e) => atualizar("volume", e.target.value)}
+                onKeyDown={(e) => handleKeyDown(e, 2)}
+                style={{ ...estilos.input, flex: 1 }}
               />
+              <select
+                value={editado.volumeUnidade || "mL"}
+                onChange={(e) => atualizar("volumeUnidade", e.target.value)}
+                style={{ ...estilos.input, width: "90px" }}
+              >
+                <option value="mL">mL</option>
+                <option value="litros">litros</option>
+              </select>
             </div>
-          ))}
+          </div>
+          <div style={estilos.campo}>
+            <label>Valor Total</label>
+            <input
+              ref={(el) => (camposRef.current[3] = el)}
+              type="number"
+              value={editado.valorTotal || ""}
+              onChange={(e) => atualizar("valorTotal", e.target.value)}
+              onKeyDown={(e) => handleKeyDown(e, 3)}
+              style={estilos.input}
+            />
+          </div>
+          <div style={estilos.campo}>
+            <label>Validade</label>
+            <input
+              ref={(el) => (camposRef.current[4] = el)}
+              type="date"
+              value={editado.validade || ""}
+              onChange={(e) => atualizar("validade", e.target.value)}
+              onKeyDown={(e) => handleKeyDown(e, 4)}
+              style={estilos.input}
+            />
+          </div>
         </div>
 
         <div style={estilos.botoes}>


### PR DESCRIPTION
## Summary
- registrar unidade do volume do produto
- exibir volume com unidade na listagem de estoque
- considerar unidade do volume ao calcular preço por mL
- atualizar edição de produtos
- corrigir cálculo de custo diário dos ciclos de limpeza

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844bfa3eebc8328a270955563de3913