### PR TITLE
Implement modal confirmation for diet deletion

### DIFF
--- a/src/components/ModalConfirmacao.jsx
+++ b/src/components/ModalConfirmacao.jsx
@@ -1,0 +1,77 @@
+import React from "react";
+
+export default function ModalConfirmacao({
+  titulo = "❗ Confirmar Exclusão",
+  mensagem = "Deseja realmente excluir?",
+  textoCancelar = "Cancelar",
+  textoConfirmar = "Excluir",
+  onCancelar,
+  onConfirmar,
+}) {
+  return (
+    <div style={estilos.overlay}>
+      <div style={estilos.modal}>
+        <h3 style={estilos.titulo}>{titulo}</h3>
+        <p style={estilos.texto}>{mensagem}</p>
+        <div style={estilos.botoes}>
+          <button onClick={onCancelar} style={estilos.btnCancelar}>
+            {textoCancelar}
+          </button>
+          <button onClick={onConfirmar} style={estilos.btnConfirmar}>
+            {textoConfirmar}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const estilos = {
+  overlay: {
+    position: "fixed",
+    inset: 0,
+    backgroundColor: "rgba(0,0,0,0.5)",
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "center",
+    zIndex: 999,
+  },
+  modal: {
+    backgroundColor: "#fff",
+    padding: "2rem",
+    borderRadius: "16px",
+    width: "90%",
+    maxWidth: "400px",
+    boxShadow: "0 8px 24px rgba(0,0,0,0.2)",
+  },
+  titulo: {
+    fontSize: "1.2rem",
+    marginBottom: "1rem",
+  },
+  texto: {
+    fontSize: "1rem",
+    marginBottom: "1.5rem",
+  },
+  botoes: {
+    display: "flex",
+    justifyContent: "flex-end",
+    gap: "1rem",
+  },
+  btnCancelar: {
+    backgroundColor: "#ccc",
+    color: "#000",
+    padding: "0.5rem 1rem",
+    borderRadius: "8px",
+    fontWeight: "bold",
+    cursor: "pointer",
+  },
+  btnConfirmar: {
+    backgroundColor: "#dc3545",
+    color: "#fff",
+    padding: "0.5rem 1rem",
+    borderRadius: "8px",
+    fontWeight: "bold",
+    border: "none",
+    cursor: "pointer",
+  },
+};

--- a/src/pages/ConsumoReposicao/Estoque.jsx
+++ b/src/pages/ConsumoReposicao/Estoque.jsx
@@ -3,6 +3,7 @@ import CadastroProduto from "./CadastroProduto";
 import AjustesEstoque from "./AjustesEstoque";
 import ModalEditarProduto from "./ModalEditarProduto";
 import Select from "react-select";
+import ModalConfirmacao from "../../components/ModalConfirmacao";
 import "../../styles/botoes.css";
 import "../../styles/tabelaModerna.css";
 
@@ -205,48 +206,21 @@ export default function Estoque() {
       )}
 
       {produtoParaExcluir && (
-        <div style={{
-          position: "fixed", inset: 0, backgroundColor: "rgba(0,0,0,0.5)",
-          display: "flex", justifyContent: "center", alignItems: "center", zIndex: 999
-        }}>
-          <div style={{
-            backgroundColor: "#fff", padding: "2rem", borderRadius: "16px",
-            width: "90%", maxWidth: "400px", boxShadow: "0 8px 24px rgba(0,0,0,0.2)"
-          }}>
-            <h3 style={{ fontSize: "1.2rem", marginBottom: "1rem" }}>❗ Confirmar Exclusão</h3>
-            <p style={{ fontSize: "1rem", marginBottom: "1.5rem" }}>
-              Deseja realmente excluir o produto <strong>{produtoParaExcluir.nomeComercial || "sem nome"}</strong>?
-            </p>
-            <div style={{ display: "flex", justifyContent: "flex-end", gap: "1rem" }}>
-              <button
-                onClick={() => setProdutoParaExcluir(null)}
-                style={{
-                  backgroundColor: "#ccc", color: "#000", padding: "0.5rem 1rem",
-                  borderRadius: "8px", fontWeight: "bold", cursor: "pointer"
-                }}
-              >
-                Cancelar
-              </button>
-              <button
-                onClick={() => {
-                  const lista = JSON.parse(localStorage.getItem("produtos") || "[]");
-                  const novaLista = lista.filter(
-                    (p) => JSON.stringify(p) !== JSON.stringify(produtoParaExcluir)
-                  );
-                  localStorage.setItem("produtos", JSON.stringify(novaLista));
-                  window.dispatchEvent(new Event("produtosAtualizados"));
-                  setProdutoParaExcluir(null);
-                }}
-                style={{
-                  backgroundColor: "#dc3545", color: "#fff", padding: "0.5rem 1rem",
-                  borderRadius: "8px", fontWeight: "bold", border: "none", cursor: "pointer"
-                }}
-              >
-                Confirmar
-              </button>
-            </div>
-          </div>
-        </div>
+        <ModalConfirmacao
+          mensagem={`Deseja realmente excluir o produto \u201c${
+            produtoParaExcluir.nomeComercial || "sem nome"
+          }\u201d?`}
+          onCancelar={() => setProdutoParaExcluir(null)}
+          onConfirmar={() => {
+            const lista = JSON.parse(localStorage.getItem("produtos") || "[]");
+            const novaLista = lista.filter(
+              (p) => JSON.stringify(p) !== JSON.stringify(produtoParaExcluir)
+            );
+            localStorage.setItem("produtos", JSON.stringify(novaLista));
+            window.dispatchEvent(new Event("produtosAtualizados"));
+            setProdutoParaExcluir(null);
+          }}
+        />
       )}
     </div>
   );

--- a/src/pages/ConsumoReposicao/ListaDietas.jsx
+++ b/src/pages/ConsumoReposicao/ListaDietas.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import CadastroDietas from "./CadastroDietas";
 import "../../styles/tabelaModerna.css";
 import "../../styles/botoes.css";
+import ModalConfirmacao from "../../components/ModalConfirmacao";
 
 export default function ListaDietas() {
   const [dietas, setDietas] = useState([]);
@@ -9,6 +10,7 @@ export default function ListaDietas() {
   const [colunaHover, setColunaHover] = useState(null);
   const [dietaEditar, setDietaEditar] = useState(null);
   const [indiceEditar, setIndiceEditar] = useState(null);
+  const [dietaParaExcluir, setDietaParaExcluir] = useState(null);
 
   const carregar = () => {
     const armazenadas = JSON.parse(localStorage.getItem("dietas") || "[]");
@@ -119,19 +121,7 @@ export default function ListaDietas() {
                     </button>
                     <button
                       className="botao-editar"
-                      onClick={() => {
-                        if (window.confirm("Deseja excluir esta dieta?")) {
-                          const atualizadas = dietas.filter((_, i) => i !== idx);
-                          localStorage.setItem(
-                            "dietas",
-                            JSON.stringify(atualizadas)
-                          );
-                          setDietas(atualizadas);
-                          window.dispatchEvent(
-                            new Event("dietasAtualizadas")
-                          );
-                        }
-                      }}
+                      onClick={() => setDietaParaExcluir({ dieta: d, indice: idx })}
                       style={{ borderColor: "#dc3545", color: "#dc3545" }}
                     >
                       🗑️ Excluir
@@ -198,6 +188,20 @@ export default function ListaDietas() {
           onSalvar={salvarDieta}
           dieta={dietaEditar}
           indice={indiceEditar}
+        />
+      )}
+
+      {dietaParaExcluir && (
+        <ModalConfirmacao
+          mensagem="Deseja realmente excluir esta dieta?"
+          onCancelar={() => setDietaParaExcluir(null)}
+          onConfirmar={() => {
+            const atualizadas = dietas.filter((_, i) => i !== dietaParaExcluir.indice);
+            localStorage.setItem("dietas", JSON.stringify(atualizadas));
+            setDietas(atualizadas);
+            setDietaParaExcluir(null);
+            window.dispatchEvent(new Event("dietasAtualizadas"));
+          }}
         />
       )}
     </div>

--- a/src/pages/ConsumoReposicao/ListaProdutos.jsx
+++ b/src/pages/ConsumoReposicao/ListaProdutos.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import "../../styles/tabelaModerna.css";
 import "../../styles/botoes.css";
 import ModalEditarProduto from "./ModalEditarProduto";
+import ModalConfirmacao from "../../components/ModalConfirmacao";
 
 export default function ListaProdutos({ categoriaFiltro }) {
   const [produtos, setProdutos] = useState([]);
@@ -190,87 +191,22 @@ export default function ListaProdutos({ categoriaFiltro }) {
       )}
 
       {produtoParaExcluir && (
-        <div style={estilos.overlay}>
-          <div style={estilos.modal}>
-            <h3 style={estilos.titulo}>❗ Confirmar Exclusão</h3>
-            <p style={estilos.texto}>
-              Deseja realmente excluir o produto <strong>{produtoParaExcluir.nomeComercial || "sem nome"}</strong>?
-            </p>
-            <div style={estilos.botoes}>
-              <button
-                onClick={() => setProdutoParaExcluir(null)}
-                style={estilos.btnCancelar}
-              >
-                Cancelar
-              </button>
-              <button
-                onClick={() => {
-                  const lista = JSON.parse(localStorage.getItem("produtos") || "[]");
-                  const novaLista = lista.filter(
-                    (p) => JSON.stringify(p) !== JSON.stringify(produtoParaExcluir)
-                  );
-                  localStorage.setItem("produtos", JSON.stringify(novaLista));
-                  window.dispatchEvent(new Event("produtosAtualizados"));
-                  setProdutoParaExcluir(null);
-                }}
-                style={estilos.btnConfirmar}
-              >
-                Confirmar
-              </button>
-            </div>
-          </div>
-        </div>
+        <ModalConfirmacao
+          mensagem={`Deseja realmente excluir o produto \u201c${
+            produtoParaExcluir.nomeComercial || "sem nome"
+          }\u201d?`}
+          onCancelar={() => setProdutoParaExcluir(null)}
+          onConfirmar={() => {
+            const lista = JSON.parse(localStorage.getItem("produtos") || "[]");
+            const novaLista = lista.filter(
+              (p) => JSON.stringify(p) !== JSON.stringify(produtoParaExcluir)
+            );
+            localStorage.setItem("produtos", JSON.stringify(novaLista));
+            window.dispatchEvent(new Event("produtosAtualizados"));
+            setProdutoParaExcluir(null);
+          }}
+        />
       )}
     </div>
   );
 }
-
-const estilos = {
-  overlay: {
-    position: "fixed",
-    inset: 0,
-    backgroundColor: "rgba(0,0,0,0.5)",
-    display: "flex",
-    justifyContent: "center",
-    alignItems: "center",
-    zIndex: 999
-  },
-  modal: {
-    backgroundColor: "#fff",
-    padding: "2rem",
-    borderRadius: "16px",
-    width: "90%",
-    maxWidth: "400px",
-    boxShadow: "0 8px 24px rgba(0,0,0,0.2)"
-  },
-  titulo: {
-    fontSize: "1.2rem",
-    marginBottom: "1rem"
-  },
-  texto: {
-    fontSize: "1rem",
-    marginBottom: "1.5rem"
-  },
-  botoes: {
-    display: "flex",
-    justifyContent: "flex-end",
-    gap: "1rem"
-  },
-  btnCancelar: {
-    backgroundColor: "#ccc",
-    color: "#000",
-    padding: "0.5rem 1rem",
-    borderRadius: "8px",
-    fontWeight: "bold",
-    cursor: "pointer"
-  },
-  btnConfirmar: {
-    backgroundColor: "#dc3545",
-    color: "#fff",
-    padding: "0.5rem 1rem",
-    borderRadius: "8px",
-    fontWeight: "bold",
-    border: "none",
-    cursor: "pointer"
-  }
-};


### PR DESCRIPTION
## Summary
- add reusable `ModalConfirmacao` component
- swap deletion popups in Estoque and ListaProdutos for `ModalConfirmacao`
- add confirmation modal to delete Dietas

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844c8cef1908328b74d8bf83366b752