### PR TITLE
Standardize delete confirmation modal

### DIFF
--- a/src/components/ModalConfirmarExclusao.jsx
+++ b/src/components/ModalConfirmarExclusao.jsx
@@ -1,0 +1,47 @@
+import React, { useEffect } from "react";
+import "../styles/botoes.css";
+
+export default function ModalConfirmarExclusao({
+  mensagem = "Deseja realmente excluir este item?",
+  onConfirmar,
+  onCancelar,
+}) {
+  useEffect(() => {
+    const esc = (e) => e.key === "Escape" && onCancelar?.();
+    window.addEventListener("keydown", esc);
+    return () => window.removeEventListener("keydown", esc);
+  }, [onCancelar]);
+
+  return (
+    <div style={overlay}>
+      <div style={modal}>
+        <h3 style={{ marginBottom: "0.75rem", fontSize: "1.1rem" }}>
+          ❗ Confirmar Exclusão
+        </h3>
+        <p style={{ marginBottom: "1.25rem" }}>{mensagem}</p>
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: "0.75rem" }}>
+          <button className="botao-cancelar" onClick={onCancelar}>Cancelar</button>
+          <button className="botao-excluir" onClick={onConfirmar}>Excluir</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const overlay = {
+  position: "fixed",
+  inset: 0,
+  backgroundColor: "rgba(0,0,0,0.5)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 9999,
+};
+
+const modal = {
+  backgroundColor: "#fff",
+  padding: "1.5rem",
+  borderRadius: "0.75rem",
+  width: "90%",
+  maxWidth: "420px",
+};

--- a/src/pages/Animais/RelatorioMedicamentos.jsx
+++ b/src/pages/Animais/RelatorioMedicamentos.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import ModalConfirmarExclusao from "../../components/ModalConfirmarExclusao";
 
 export default function RelatorioMedicamentos({ onFechar }) {
   const [medicamentos, setMedicamentos] = useState({});
@@ -102,19 +103,12 @@ export default function RelatorioMedicamentos({ onFechar }) {
         </div>
       </div>
 
-      {/* Modal de Confirmação */}
       {confirmarExclusao && (
-        <div style={confirmBackdrop}>
-          <div style={confirmBox}>
-            <p style={{ fontWeight: "bold", fontSize: "1rem" }}>
-              Tem certeza que deseja excluir <u>{confirmarExclusao}</u>?
-            </p>
-            <div style={{ display: "flex", justifyContent: "flex-end", gap: "1rem", marginTop: "1.25rem" }}>
-              <button onClick={() => setConfirmarExclusao(null)} style={btnCinza}>Cancelar</button>
-              <button onClick={() => excluir(confirmarExclusao)} style={btnVermelho}>Confirmar</button>
-            </div>
-          </div>
-        </div>
+        <ModalConfirmarExclusao
+          mensagem={`Tem certeza que deseja excluir \u201c${confirmarExclusao}\u201d?`}
+          onCancelar={() => setConfirmarExclusao(null)}
+          onConfirmar={() => excluir(confirmarExclusao)}
+        />
       )}
     </div>
   );
@@ -159,13 +153,3 @@ const btnFechar = {
   ...btnCinza, padding: "0.6rem 1.2rem", fontWeight: "500"
 };
 
-// Modal confirmação
-const confirmBackdrop = {
-  position: "fixed", inset: 0, backgroundColor: "rgba(0,0,0,0.6)",
-  display: "flex", justifyContent: "center", alignItems: "center", zIndex: 10001
-};
-
-const confirmBox = {
-  background: "#fff", padding: "2rem", borderRadius: "1rem", width: "400px",
-  fontFamily: "Poppins, sans-serif", textAlign: "center"
-};

--- a/src/pages/ConsumoReposicao/Estoque.jsx
+++ b/src/pages/ConsumoReposicao/Estoque.jsx
@@ -3,7 +3,7 @@ import CadastroProduto from "./CadastroProduto";
 import AjustesEstoque from "./AjustesEstoque";
 import ModalEditarProduto from "./ModalEditarProduto";
 import Select from "react-select";
-import ModalConfirmacao from "../../components/ModalConfirmacao";
+import ModalConfirmarExclusao from "../../components/ModalConfirmarExclusao";
 import "../../styles/botoes.css";
 import "../../styles/tabelaModerna.css";
 
@@ -206,7 +206,7 @@ export default function Estoque() {
       )}
 
       {produtoParaExcluir && (
-        <ModalConfirmacao
+        <ModalConfirmarExclusao
           mensagem={`Deseja realmente excluir o produto \u201c${
             produtoParaExcluir.nomeComercial || "sem nome"
           }\u201d?`}

--- a/src/pages/ConsumoReposicao/ListaCalendarioVacinal.jsx
+++ b/src/pages/ConsumoReposicao/ListaCalendarioVacinal.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from "react";
 import ModalCadastroManejoSanitario from "./ModalCadastroManejoSanitario";
 import ModalRegistroAplicacao from "./ModalRegistroAplicacao";
+import ModalConfirmarExclusao from "../../components/ModalConfirmarExclusao";
 import "../../styles/tabelaModerna.css";
 import "../../styles/botoes.css";
 
@@ -10,6 +11,7 @@ export default function ListaCalendarioVacinal() {
   const [indiceEditar, setIndiceEditar] = useState(null);
   const [registrar, setRegistrar] = useState(null);
   const [indiceRegistrar, setIndiceRegistrar] = useState(null);
+  const [manejoExcluir, setManejoExcluir] = useState(null);
 
   useEffect(() => {
     const carregar = () => {
@@ -38,6 +40,14 @@ export default function ListaCalendarioVacinal() {
     setIndiceRegistrar(null);
     const lista = JSON.parse(localStorage.getItem("manejosSanitarios") || "[]");
     setManejos(lista);
+  };
+
+  const removerManejo = (index) => {
+    const nova = manejos.filter((_, i) => i !== index);
+    localStorage.setItem("manejosSanitarios", JSON.stringify(nova));
+    setManejos(nova);
+    window.dispatchEvent(new Event("manejosSanitariosAtualizados"));
+    setManejoExcluir(null);
   };
 
   return (
@@ -79,14 +89,7 @@ export default function ListaCalendarioVacinal() {
                     <button
                       className="botao-editar"
                       style={{ borderColor: "#dc3545", color: "#dc3545" }}
-                      onClick={() => {
-                        if (window.confirm("Deseja excluir este manejo?")) {
-                          const nova = manejos.filter((_, i) => i !== idx);
-                          localStorage.setItem("manejosSanitarios", JSON.stringify(nova));
-                          setManejos(nova);
-                          window.dispatchEvent(new Event("manejosSanitariosAtualizados"));
-                        }
-                      }}
+                      onClick={() => setManejoExcluir(idx)}
                     >
                       Excluir
                     </button>
@@ -111,6 +114,14 @@ export default function ListaCalendarioVacinal() {
           manejo={registrar}
           indice={indiceRegistrar}
           onFechar={fecharRegistro}
+        />
+      )}
+
+      {manejoExcluir !== null && (
+        <ModalConfirmarExclusao
+          mensagem="Deseja realmente excluir este manejo?"
+          onCancelar={() => setManejoExcluir(null)}
+          onConfirmar={() => removerManejo(manejoExcluir)}
         />
       )}
     </div>

--- a/src/pages/ConsumoReposicao/ListaDietas.jsx
+++ b/src/pages/ConsumoReposicao/ListaDietas.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import CadastroDietas from "./CadastroDietas";
 import "../../styles/tabelaModerna.css";
 import "../../styles/botoes.css";
-import ModalConfirmacao from "../../components/ModalConfirmacao";
+import ModalConfirmarExclusao from "../../components/ModalConfirmarExclusao";
 
 export default function ListaDietas() {
   const [dietas, setDietas] = useState([]);
@@ -192,7 +192,7 @@ export default function ListaDietas() {
       )}
 
       {dietaParaExcluir && (
-        <ModalConfirmacao
+        <ModalConfirmarExclusao
           mensagem="Deseja realmente excluir esta dieta?"
           onCancelar={() => setDietaParaExcluir(null)}
           onConfirmar={() => {

--- a/src/pages/ConsumoReposicao/ListaLimpeza.jsx
+++ b/src/pages/ConsumoReposicao/ListaLimpeza.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react";
 import ModalPlanoCiclo from "./ModalPlanoCiclo";
+import ModalConfirmarExclusao from "../../components/ModalConfirmarExclusao";
 import "../../styles/tabelaModerna.css";
 import "../../styles/botoes.css";
 
@@ -9,6 +10,7 @@ export default function ListaLimpeza({ onEditar }) {
   const [ciclos, setCiclos] = useState([]);
   const [colunaHover, setColunaHover] = useState(null);
   const [planoAtivo, setPlanoAtivo] = useState(null);
+  const [cicloExcluir, setCicloExcluir] = useState(null);
 
   const carregar = () => {
     const lista = JSON.parse(localStorage.getItem("ciclosLimpeza") || "[]");
@@ -214,12 +216,12 @@ export default function ListaLimpeza({ onEditar }) {
     return linhas.join("\n");
   };
 
-  const excluir = (index) => {
-    if (!window.confirm("Deseja excluir este ciclo?")) return;
+  const removerCiclo = (index) => {
     const atualizados = ciclos.filter((_, i) => i !== index);
     setCiclos(atualizados);
     localStorage.setItem("ciclosLimpeza", JSON.stringify(atualizados));
     window.dispatchEvent(new Event("ciclosLimpezaAtualizados"));
+    setCicloExcluir(null);
   };
 
   const titulos = [
@@ -299,7 +301,7 @@ export default function ListaLimpeza({ onEditar }) {
                   <td style={{ whiteSpace: "nowrap" }}>
                     <div style={{ display: "flex", gap: "0.4rem" }}>
                       <button className="botao-editar" onClick={() => onEditar(c, index)}>Editar</button>
-                      <button className="botao-editar" onClick={() => excluir(index)} style={{ borderColor: "#dc3545", color: "#dc3545" }}>Excluir</button>
+                      <button className="botao-editar" onClick={() => setCicloExcluir(index)} style={{ borderColor: "#dc3545", color: "#dc3545" }}>Excluir</button>
                       <button className="botao-editar" onClick={() => setPlanoAtivo(index)} style={{ borderColor: "#6b7280", color: "#6b7280" }}>Ver plano</button>
                     </div>
                   </td>
@@ -314,6 +316,14 @@ export default function ListaLimpeza({ onEditar }) {
         <ModalPlanoCiclo
           ciclo={ciclos[planoAtivo]}
           onClose={() => setPlanoAtivo(null)}
+        />
+      )}
+
+      {cicloExcluir !== null && (
+        <ModalConfirmarExclusao
+          mensagem="Deseja realmente excluir este ciclo?"
+          onCancelar={() => setCicloExcluir(null)}
+          onConfirmar={() => removerCiclo(cicloExcluir)}
         />
       )}
     </>

--- a/src/pages/ConsumoReposicao/ListaLotes.jsx
+++ b/src/pages/ConsumoReposicao/ListaLotes.jsx
@@ -2,11 +2,13 @@ import React, { useEffect, useState } from "react";
 import "../../styles/tabelaModerna.css";
 import "../../styles/botoes.css";
 import ModalInfoLote from "./ModalInfoLote";
+import ModalConfirmarExclusao from "../../components/ModalConfirmarExclusao";
 
 export default function ListaLotes({ onAbrirCadastro }) {
   const [lotes, setLotes] = useState([]);
   const [colunaHover, setColunaHover] = useState(null);
   const [modalLote, setModalLote] = useState(null);
+  const [loteExcluir, setLoteExcluir] = useState(null);
 
   const carregar = () => {
     const dados = JSON.parse(localStorage.getItem("lotes") || "[]");
@@ -35,12 +37,12 @@ export default function ListaLotes({ onAbrirCadastro }) {
     window.dispatchEvent(new Event("lotesAtualizados"));
   };
 
-  const excluir = (index) => {
-    if (!window.confirm("Deseja excluir este lote?")) return;
+  const removerLote = (index) => {
     const atualizados = lotes.filter((_, i) => i !== index);
     setLotes(atualizados);
     localStorage.setItem("lotes", JSON.stringify(atualizados));
     window.dispatchEvent(new Event("lotesAtualizados"));
+    setLoteExcluir(null);
   };
 
   const abrirModal = (lote) => {
@@ -113,7 +115,7 @@ export default function ListaLotes({ onAbrirCadastro }) {
                     </button>
                     <button
                       className="botao-editar"
-                      onClick={() => excluir(index)}
+                      onClick={() => setLoteExcluir(index)}
                       style={{ borderColor: "#dc3545", color: "#dc3545" }}
                     >
                       Excluir
@@ -130,6 +132,14 @@ export default function ListaLotes({ onAbrirCadastro }) {
           nomeDoLote={modalLote.nome}
           funcaoDoLote={modalLote.funcao}
           onFechar={fecharModal}
+        />
+      )}
+
+      {loteExcluir !== null && (
+        <ModalConfirmarExclusao
+          mensagem="Deseja realmente excluir este lote?"
+          onCancelar={() => setLoteExcluir(null)}
+          onConfirmar={() => removerLote(loteExcluir)}
         />
       )}
     </div>

--- a/src/pages/ConsumoReposicao/ListaProdutos.jsx
+++ b/src/pages/ConsumoReposicao/ListaProdutos.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import "../../styles/tabelaModerna.css";
 import "../../styles/botoes.css";
 import ModalEditarProduto from "./ModalEditarProduto";
-import ModalConfirmacao from "../../components/ModalConfirmacao";
+import ModalConfirmarExclusao from "../../components/ModalConfirmarExclusao";
 
 export default function ListaProdutos({ categoriaFiltro }) {
   const [produtos, setProdutos] = useState([]);
@@ -191,7 +191,7 @@ export default function ListaProdutos({ categoriaFiltro }) {
       )}
 
       {produtoParaExcluir && (
-        <ModalConfirmacao
+        <ModalConfirmarExclusao
           mensagem={`Deseja realmente excluir o produto \u201c${
             produtoParaExcluir.nomeComercial || "sem nome"
           }\u201d?`}

--- a/src/pages/Reproducao/ProtocolosReprodutivos.jsx
+++ b/src/pages/Reproducao/ProtocolosReprodutivos.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import ModalCadastroProtocolo from "./ModalCadastroProtocolo";
+import ModalConfirmarExclusao from "../../components/ModalConfirmarExclusao";
 import "../../styles/tabelaModerna.css";
 import "../../styles/botoes.css";
 
@@ -8,15 +9,15 @@ export default function ProtocolosReprodutivos() {
   const [protocolos, setProtocolos] = useState([]);
   const [colunaHover, setColunaHover] = useState(null);
   const [protocoloExpandido, setProtocoloExpandido] = useState(null);
+  const [protocoloExcluir, setProtocoloExcluir] = useState(null);
 
   const salvarProtocolo = (novoProtocolo) => {
     setProtocolos([...protocolos, novoProtocolo]);
   };
 
-  const excluirProtocolo = (index) => {
-    if (window.confirm("Tem certeza que deseja excluir este protocolo?")) {
-      setProtocolos(protocolos.filter((_, i) => i !== index));
-    }
+  const removerProtocolo = (index) => {
+    setProtocolos(protocolos.filter((_, i) => i !== index));
+    setProtocoloExcluir(null);
   };
 
   const editarProtocolo = (index) => {
@@ -90,7 +91,7 @@ export default function ProtocolosReprodutivos() {
                         ✏️ Editar
                       </button>
                       <button
-                        onClick={() => excluirProtocolo(index)}
+                        onClick={() => setProtocoloExcluir(index)}
                         className="botao-acao pequeno"
                       >
                         🗑️ Excluir
@@ -122,6 +123,14 @@ export default function ProtocolosReprodutivos() {
         <ModalCadastroProtocolo
           onFechar={() => setModalAberto(false)}
           onSalvar={salvarProtocolo}
+        />
+      )}
+
+      {protocoloExcluir !== null && (
+        <ModalConfirmarExclusao
+          mensagem="Tem certeza que deseja excluir este protocolo?"
+          onCancelar={() => setProtocoloExcluir(null)}
+          onConfirmar={() => removerProtocolo(protocoloExcluir)}
         />
       )}
     </div>

--- a/src/styles/botoes.css
+++ b/src/styles/botoes.css
@@ -61,3 +61,17 @@
 .botao-cancelar:active {
   transform: scale(0.98);
 }
+
+.botao-excluir {
+  background-color: #e63946;
+  color: white;
+  padding: 6px 14px;
+  border: none;
+  border-radius: 6px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.botao-excluir:hover {
+  background-color: #d62828;
+}


### PR DESCRIPTION
## Summary
- add `ModalConfirmarExclusao` component
- style new delete and cancel buttons
- use new modal in Estoque, Produtos, Dietas, Limpeza, Lotes, Manejos, Protocolos and Relatório de Medicamentos

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844cc8709cc83289d9336e5dba06e07