### PR TITLE
Padroniza botoes e modal de exclusao

### DIFF
--- a/src/components/ModalExclusaoPadrao.jsx
+++ b/src/components/ModalExclusaoPadrao.jsx
@@ -1,0 +1,2 @@
+import ModalConfirmarExclusao from './ModalConfirmarExclusao';
+export default ModalConfirmarExclusao;

--- a/src/pages/ConsumoReposicao/Estoque.jsx
+++ b/src/pages/ConsumoReposicao/Estoque.jsx
@@ -3,7 +3,7 @@ import CadastroProduto from "./CadastroProduto";
 import AjustesEstoque from "./AjustesEstoque";
 import ModalEditarProduto from "./ModalEditarProduto";
 import Select from "react-select";
-import ModalConfirmarExclusao from "../../components/ModalConfirmarExclusao";
+import ModalExclusaoPadrao from "../../components/ModalExclusaoPadrao";
 import "../../styles/botoes.css";
 import "../../styles/tabelaModerna.css";
 
@@ -152,19 +152,13 @@ export default function Estoque() {
                     <div style={{ display: "flex", gap: "0.4rem" }}>
                       <button
                         onClick={() => abrirModalEdicao(p, index)}
-                        style={{
-                          backgroundColor: "#007bff", color: "#fff", border: "none",
-                          borderRadius: "8px", padding: "0.4rem 0.8rem", fontWeight: "bold"
-                        }}
+                        className="btn-editar"
                       >
                         Editar
                       </button>
                       <button
                         onClick={() => confirmarExclusao(p)}
-                        style={{
-                          backgroundColor: "#dc3545", color: "#fff", border: "none",
-                          borderRadius: "8px", padding: "0.4rem 0.8rem", fontWeight: "bold"
-                        }}
+                        className="btn-excluir"
                       >
                         Excluir
                       </button>
@@ -206,7 +200,7 @@ export default function Estoque() {
       )}
 
       {produtoParaExcluir && (
-        <ModalConfirmarExclusao
+        <ModalExclusaoPadrao
           mensagem={`Deseja realmente excluir o produto \u201c${
             produtoParaExcluir.nomeComercial || "sem nome"
           }\u201d?`}

--- a/src/pages/ConsumoReposicao/ListaDietas.jsx
+++ b/src/pages/ConsumoReposicao/ListaDietas.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import CadastroDietas from "./CadastroDietas";
 import "../../styles/tabelaModerna.css";
 import "../../styles/botoes.css";
-import ModalConfirmarExclusao from "../../components/ModalConfirmarExclusao";
+import ModalExclusaoPadrao from "../../components/ModalExclusaoPadrao";
 
 export default function ListaDietas() {
   const [dietas, setDietas] = useState([]);
@@ -110,7 +110,7 @@ export default function ListaDietas() {
                 <td className="coluna-acoes">
                   <div className="botoes-tabela">
                     <button
-                      className="botao-editar"
+                      className="btn-editar"
                       onClick={() => {
                         setDietaEditar(d);
                         setIndiceEditar(idx);
@@ -120,9 +120,8 @@ export default function ListaDietas() {
                       ✏️ Editar
                     </button>
                     <button
-                      className="botao-editar"
+                      className="btn-excluir"
                       onClick={() => setDietaParaExcluir({ dieta: d, indice: idx })}
-                      style={{ borderColor: "#dc3545", color: "#dc3545" }}
                     >
                       🗑️ Excluir
                     </button>
@@ -192,7 +191,7 @@ export default function ListaDietas() {
       )}
 
       {dietaParaExcluir && (
-        <ModalConfirmarExclusao
+        <ModalExclusaoPadrao
           mensagem="Deseja realmente excluir esta dieta?"
           onCancelar={() => setDietaParaExcluir(null)}
           onConfirmar={() => {

--- a/src/pages/ConsumoReposicao/ListaLimpeza.jsx
+++ b/src/pages/ConsumoReposicao/ListaLimpeza.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import ModalPlanoCiclo from "./ModalPlanoCiclo";
-import ModalConfirmarExclusao from "../../components/ModalConfirmarExclusao";
+import ModalExclusaoPadrao from "../../components/ModalExclusaoPadrao";
 import "../../styles/tabelaModerna.css";
 import "../../styles/botoes.css";
 
@@ -164,12 +164,16 @@ export default function ListaLimpeza({ onEditar }) {
 
       const volumeStr = String(produto.volume).toLowerCase();
       const volumeNumerico = parseFloat(volumeStr);
-      const volumeEmML = volumeStr.includes("l") ? volumeNumerico * 1000 : volumeNumerico;
+      let volumeEmML = volumeStr.includes("l") ? volumeNumerico * 1000 : volumeNumerico;
       if (!volumeEmML || isNaN(volumeEmML)) return;
 
-      const precoPorML = parseFloat(produto.valorTotal) / volumeEmML;
-      const consumoPorDia = parseFloat(etapa.quantidade || 0) * freq;
-      total += consumoPorDia * precoPorML;
+      const unidades = parseFloat(produto.quantidade) || 1;
+      volumeEmML *= unidades;
+      const valorTotal = parseFloat(produto.valorTotal) || 0;
+      const precoPorML = volumeEmML > 0 ? valorTotal / volumeEmML : 0;
+      const quantidadeUsada = parseFloat(etapa.quantidade || 0) * freq;
+      const custoEtapa = precoPorML * quantidadeUsada;
+      total += custoEtapa;
     });
 
     return total > 0 ? `R$ ${total.toFixed(2)}` : "—";
@@ -300,9 +304,9 @@ export default function ListaLimpeza({ onEditar }) {
                   </td>
                   <td style={{ whiteSpace: "nowrap" }}>
                     <div style={{ display: "flex", gap: "0.4rem" }}>
-                      <button className="botao-editar" onClick={() => onEditar(c, index)}>Editar</button>
-                      <button className="botao-editar" onClick={() => setCicloExcluir(index)} style={{ borderColor: "#dc3545", color: "#dc3545" }}>Excluir</button>
-                      <button className="botao-editar" onClick={() => setPlanoAtivo(index)} style={{ borderColor: "#6b7280", color: "#6b7280" }}>Ver plano</button>
+                      <button className="btn-editar" onClick={() => onEditar(c, index)}>Editar</button>
+                      <button className="btn-excluir" onClick={() => setCicloExcluir(index)}>Excluir</button>
+                      <button className="btn-editar" onClick={() => setPlanoAtivo(index)} style={{ backgroundColor: "#6b7280" }}>Ver plano</button>
                     </div>
                   </td>
                 </tr>
@@ -320,7 +324,7 @@ export default function ListaLimpeza({ onEditar }) {
       )}
 
       {cicloExcluir !== null && (
-        <ModalConfirmarExclusao
+        <ModalExclusaoPadrao
           mensagem="Deseja realmente excluir este ciclo?"
           onCancelar={() => setCicloExcluir(null)}
           onConfirmar={() => removerCiclo(cicloExcluir)}

--- a/src/pages/ConsumoReposicao/ListaLotes.jsx
+++ b/src/pages/ConsumoReposicao/ListaLotes.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 import "../../styles/tabelaModerna.css";
 import "../../styles/botoes.css";
 import ModalInfoLote from "./ModalInfoLote";
-import ModalConfirmarExclusao from "../../components/ModalConfirmarExclusao";
+import ModalExclusaoPadrao from "../../components/ModalExclusaoPadrao";
 
 export default function ListaLotes({ onAbrirCadastro }) {
   const [lotes, setLotes] = useState([]);
@@ -108,15 +108,14 @@ export default function ListaLotes({ onAbrirCadastro }) {
                 <td>
                   <div style={{ display: "flex", gap: "0.4rem" }}>
                     <button
-                      className="botao-editar"
+                      className="btn-editar"
                       onClick={() => alternarAtivo(index)}
                     >
                       {l.ativo ? "Inativar" : "Ativar"}
                     </button>
                     <button
-                      className="botao-editar"
+                      className="btn-excluir"
                       onClick={() => setLoteExcluir(index)}
-                      style={{ borderColor: "#dc3545", color: "#dc3545" }}
                     >
                       Excluir
                     </button>
@@ -136,7 +135,7 @@ export default function ListaLotes({ onAbrirCadastro }) {
       )}
 
       {loteExcluir !== null && (
-        <ModalConfirmarExclusao
+        <ModalExclusaoPadrao
           mensagem="Deseja realmente excluir este lote?"
           onCancelar={() => setLoteExcluir(null)}
           onConfirmar={() => removerLote(loteExcluir)}

--- a/src/pages/ConsumoReposicao/ListaProdutos.jsx
+++ b/src/pages/ConsumoReposicao/ListaProdutos.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import "../../styles/tabelaModerna.css";
 import "../../styles/botoes.css";
 import ModalEditarProduto from "./ModalEditarProduto";
-import ModalConfirmarExclusao from "../../components/ModalConfirmarExclusao";
+import ModalExclusaoPadrao from "../../components/ModalExclusaoPadrao";
 
 export default function ListaProdutos({ categoriaFiltro }) {
   const [produtos, setProdutos] = useState([]);
@@ -139,30 +139,14 @@ export default function ListaProdutos({ categoriaFiltro }) {
                       <button
                         type="button"
                         onClick={() => abrirModalEdicao(p, index)}
-                        style={{
-                          backgroundColor: "#007bff",
-                          color: "#fff",
-                          border: "none",
-                          borderRadius: "8px",
-                          padding: "0.4rem 0.8rem",
-                          fontWeight: "bold",
-                          cursor: "pointer"
-                        }}
+                        className="btn-editar"
                       >
                         Editar
                       </button>
                       <button
                         type="button"
                         onClick={() => confirmarExclusao(p)}
-                        style={{
-                          backgroundColor: "#dc3545",
-                          color: "#fff",
-                          border: "none",
-                          borderRadius: "8px",
-                          padding: "0.4rem 0.8rem",
-                          fontWeight: "bold",
-                          cursor: "pointer"
-                        }}
+                        className="btn-excluir"
                       >
                         Excluir
                       </button>
@@ -191,7 +175,7 @@ export default function ListaProdutos({ categoriaFiltro }) {
       )}
 
       {produtoParaExcluir && (
-        <ModalConfirmarExclusao
+        <ModalExclusaoPadrao
           mensagem={`Deseja realmente excluir o produto \u201c${
             produtoParaExcluir.nomeComercial || "sem nome"
           }\u201d?`}

--- a/src/styles/botoes.css
+++ b/src/styles/botoes.css
@@ -75,3 +75,33 @@
 .botao-excluir:hover {
   background-color: #d62828;
 }
+/* NOVOS BOTÕES PADRONIZADOS */
+.btn-editar {
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.4rem 0.8rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.btn-editar:hover {
+  background-color: #0069d9;
+}
+
+.btn-excluir {
+  background-color: #dc3545;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.4rem 0.8rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.btn-excluir:hover {
+  background-color: #c82333;
+}


### PR DESCRIPTION
## Summary
- centralize action button styles in `botoes.css`
- add alias component `ModalExclusaoPadrao`
- use new classes and modal across Estoque, Produtos, Dietas, Limpeza e Lotes
- fix daily cost calculation for cleaning cycles

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d0b049b4832896b8f74c65ca6b3d