### PR TITLE
Padroniza botoes na lista vacinal

### DIFF
--- a/src/components/ModalExclusaoPadrao.jsx
+++ b/src/components/ModalExclusaoPadrao.jsx
@@ -1,0 +1,47 @@
+import React, { useEffect } from "react";
+import "../styles/botoes.css";
+
+export default function ModalExclusaoPadrao({
+  mensagem = "Deseja realmente excluir este item?",
+  onConfirmar,
+  onCancelar,
+}) {
+  useEffect(() => {
+    const esc = (e) => e.key === "Escape" && onCancelar?.();
+    window.addEventListener("keydown", esc);
+    return () => window.removeEventListener("keydown", esc);
+  }, [onCancelar]);
+
+  return (
+    <div style={overlay}>
+      <div style={modal}>
+        <h3 style={{ marginBottom: "0.75rem", fontSize: "1.1rem" }}>
+          ❗ Confirmar Exclusão
+        </h3>
+        <p style={{ marginBottom: "1.25rem" }}>{mensagem}</p>
+        <div style={{ display: "flex", justifyContent: "flex-end", gap: "0.75rem" }}>
+          <button className="botao-cancelar" onClick={onCancelar}>Cancelar</button>
+          <button className="botao-excluir" onClick={onConfirmar}>Excluir</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const overlay = {
+  position: "fixed",
+  inset: 0,
+  backgroundColor: "rgba(0,0,0,0.5)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 9999,
+};
+
+const modal = {
+  backgroundColor: "#fff",
+  padding: "1.5rem",
+  borderRadius: "0.75rem",
+  width: "90%",
+  maxWidth: "420px",
+};

--- a/src/pages/ConsumoReposicao/ListaCalendarioVacinal.jsx
+++ b/src/pages/ConsumoReposicao/ListaCalendarioVacinal.jsx
@@ -80,15 +80,26 @@ export default function ListaCalendarioVacinal() {
                 <td>{m.proximaAplicacao ? new Date(m.proximaAplicacao).toLocaleDateString("pt-BR") : (m.dataInicial ? new Date(m.dataInicial).toLocaleDateString("pt-BR") : "—")}</td>
                 <td className="coluna-acoes">
                   <div className="botoes-tabela">
-                    <button className="botao-editar" onClick={() => { setEditar(m); setIndiceEditar(idx); }}>
+                    <button
+                      className="btn-editar"
+                      onClick={() => {
+                        setEditar(m);
+                        setIndiceEditar(idx);
+                      }}
+                    >
                       Editar
                     </button>
-                    <button className="botao-editar" onClick={() => { setRegistrar(m); setIndiceRegistrar(idx); }}>
+                    <button
+                      className="btn-registrar"
+                      onClick={() => {
+                        setRegistrar(m);
+                        setIndiceRegistrar(idx);
+                      }}
+                    >
                       Registrar
                     </button>
                     <button
-                      className="botao-editar"
-                      style={{ borderColor: "#dc3545", color: "#dc3545" }}
+                      className="btn-excluir"
                       onClick={() => setManejoExcluir(idx)}
                     >
                       Excluir

--- a/src/styles/botoes.css
+++ b/src/styles/botoes.css
@@ -105,3 +105,18 @@
 .btn-excluir:hover {
   background-color: #c82333;
 }
+
+.btn-registrar {
+  background-color: #4dabf7;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.4rem 0.8rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
+}
+
+.btn-registrar:hover {
+  background-color: #339af0;
+}


### PR DESCRIPTION
## Summary
- padroniza estilos dos botoes na `ListaCalendarioVacinal`
- adiciona modal de exclusao padrao reutilizavel
- cria estilo `btn-registrar` em `botoes.css`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844dfddedd48328abd70e38bcc1903a