### PR TITLE
Improve PEV action menu

### DIFF
--- a/src/pages/Reproducao/ModalRegistrarOcorrencia.jsx
+++ b/src/pages/Reproducao/ModalRegistrarOcorrencia.jsx
@@ -1,0 +1,186 @@
+import React, { useEffect, useState } from 'react';
+import Select from 'react-select';
+
+export default function ModalRegistrarOcorrencia({ vaca, onClose, onSalvar }) {
+  const TIPOS = [
+    'Metrite',
+    'Endometrite',
+    'Infecção Subclínica',
+    'Cio natural',
+    'Descalcificação',
+    'Cetose'
+  ];
+
+  const [tipo, setTipo] = useState('');
+  const [observacoes, setObservacoes] = useState('');
+  const [iniciarTratamento, setIniciarTratamento] = useState(false);
+  const [produto, setProduto] = useState(null);
+  const [dose, setDose] = useState('');
+  const [duracao, setDuracao] = useState('');
+  const [carencia, setCarencia] = useState('');
+  const [produtos, setProdutos] = useState([]);
+
+  useEffect(() => {
+    const lista = JSON.parse(localStorage.getItem('produtos') || '[]');
+    const farm = lista.filter(p => p.agrupamento === 'Farmácia');
+    setProdutos(farm.map(p => ({ value: p.nomeComercial, label: p.nomeComercial })));
+    const esc = e => e.key === 'Escape' && onClose?.();
+    window.addEventListener('keydown', esc);
+    return () => window.removeEventListener('keydown', esc);
+  }, [onClose]);
+
+  const salvar = () => {
+    if (!tipo) {
+      alert('Selecione o tipo de ocorrência');
+      return;
+    }
+    const hoje = new Date().toISOString().substring(0, 10);
+    const ocorrencia = {
+      numeroAnimal: vaca.numero,
+      data: hoje,
+      tipo,
+      observacoes
+    };
+    const listaOc = JSON.parse(localStorage.getItem('ocorrencias') || '[]');
+    listaOc.push(ocorrencia);
+    localStorage.setItem('ocorrencias', JSON.stringify(listaOc));
+    window.dispatchEvent(new Event('ocorrenciasAtualizadas'));
+
+    if (iniciarTratamento && produto) {
+      const tratamento = {
+        numeroAnimal: vaca.numero,
+        data: hoje,
+        produto,
+        dose,
+        duracao,
+        carencia
+      };
+      const listaTr = JSON.parse(localStorage.getItem('tratamentos') || '[]');
+      listaTr.push(tratamento);
+      localStorage.setItem('tratamentos', JSON.stringify(listaTr));
+      window.dispatchEvent(new Event('tratamentosAtualizados'));
+    }
+    onSalvar?.(ocorrencia);
+    onClose?.();
+  };
+
+  const input = () => ({
+    padding: '0.6rem',
+    border: '1px solid #ccc',
+    borderRadius: '0.5rem',
+    width: '100%',
+    fontSize: '0.95rem'
+  });
+
+  return (
+    <div style={overlay} onClick={onClose}>
+      <div style={modal} onClick={e => e.stopPropagation()}>
+        <div style={header}>Registrar Ocorrência - {vaca.numero}</div>
+        <div style={conteudo}>
+          <div>
+            <label>Tipo de Ocorrência *</label>
+            <select value={tipo} onChange={e => setTipo(e.target.value)} style={input()}>
+              <option value="">Selecione...</option>
+              {TIPOS.map(t => (
+                <option key={t} value={t}>{t}</option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label>Observações</label>
+            <textarea
+              value={observacoes}
+              onChange={e => setObservacoes(e.target.value)}
+              style={{ ...input(), height: '80px' }}
+            />
+          </div>
+          <div>
+            <label>
+              <input
+                type="checkbox"
+                checked={iniciarTratamento}
+                onChange={e => setIniciarTratamento(e.target.checked)}
+              />{' '}
+              Iniciar tratamento agora
+            </label>
+          </div>
+          {iniciarTratamento && (
+            <>
+              <div>
+                <label>Produto</label>
+                <Select
+                  options={produtos}
+                  value={produto ? { value: produto, label: produto } : null}
+                  onChange={opt => setProduto(opt?.value || null)}
+                  className="react-select-container"
+                  classNamePrefix="react-select"
+                  placeholder="Selecione..."
+                />
+              </div>
+              <div>
+                <label>Dose</label>
+                <input value={dose} onChange={e => setDose(e.target.value)} style={input()} />
+              </div>
+              <div>
+                <label>Duração (dias)</label>
+                <input
+                  type="number"
+                  value={duracao}
+                  onChange={e => setDuracao(e.target.value)}
+                  style={{ ...input(), width: '120px' }}
+                />
+              </div>
+              <div>
+                <label>Carência (Leite/Carne)</label>
+                <input value={carencia} onChange={e => setCarencia(e.target.value)} style={input()} />
+              </div>
+            </>
+          )}
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '1rem', marginTop: '1rem' }}>
+            <button onClick={onClose} className="botao-cancelar">Cancelar</button>
+            <button onClick={salvar} className="botao-acao">Salvar</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const overlay = {
+  position: 'fixed',
+  inset: 0,
+  backgroundColor: 'rgba(0,0,0,0.6)',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  zIndex: 9999
+};
+
+const modal = {
+  background: '#fff',
+  borderRadius: '1rem',
+  width: '420px',
+  maxHeight: '90vh',
+  overflowY: 'auto',
+  fontFamily: 'Poppins, sans-serif',
+  display: 'flex',
+  flexDirection: 'column'
+};
+
+const header = {
+  background: '#1e40af',
+  color: 'white',
+  padding: '1rem 1.5rem',
+  fontWeight: 'bold',
+  fontSize: '1.1rem',
+  borderTopLeftRadius: '1rem',
+  borderTopRightRadius: '1rem',
+  textAlign: 'center'
+};
+
+const conteudo = {
+  padding: '1.5rem',
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '1rem'
+};

--- a/src/pages/Reproducao/VisaoGeralReproducao.jsx
+++ b/src/pages/Reproducao/VisaoGeralReproducao.jsx
@@ -3,6 +3,7 @@ import { carregarAnimaisDoLocalStorage, calcularDEL } from '../Animais/utilsAnim
 import ModalHistoricoCompleto from "../Animais/ModalHistoricoCompleto";
 import ModalConfiguracaoPEV from "./ModalConfiguracaoPEV";
 import { getStatusVaca, getAcoesDisponiveis, filtrarAnimaisAtivos } from './utilsReproducao';
+import ModalRegistrarOcorrencia from './ModalRegistrarOcorrencia';
 import '../../styles/tabelaModerna.css';
 import '../../styles/botoes.css';
 
@@ -10,6 +11,7 @@ export default function VisaoGeralReproducao() {
   const [vacas, setVacas] = useState([]);
   const [animalFicha, setAnimalFicha] = useState(null);
   const [mostrarFicha, setMostrarFicha] = useState(false);
+  const [vacaOcorrencia, setVacaOcorrencia] = useState(null);
   const [colunaHover, setColunaHover] = useState(null);
   const [mostrarModalPEV, setMostrarModalPEV] = useState(false);
   const [configPEV, setConfigPEV] = useState({
@@ -69,7 +71,11 @@ export default function VisaoGeralReproducao() {
       <select
         onChange={(e) => {
           const acao = e.target.value;
-          if (acao !== "—") alert(`Selecionado: ${acao} para a vaca ${vaca.numero}`);
+          if (acao === 'Registrar Ocorrência') {
+            setVacaOcorrencia(vaca);
+          } else if (acao !== '—') {
+            alert(`Selecionado: ${acao} para a vaca ${vaca.numero}`);
+          }
           e.target.selectedIndex = 0;
         }}
         style={{ width: "100%", padding: "0.4rem", borderRadius: "0.5rem", border: "1px solid #ccc" }}
@@ -159,6 +165,14 @@ export default function VisaoGeralReproducao() {
         <ModalConfiguracaoPEV
           onClose={() => setMostrarModalPEV(false)}
           onAplicar={aplicarConfiguracoesPEV}
+        />
+      )}
+
+      {vacaOcorrencia && (
+        <ModalRegistrarOcorrencia
+          vaca={vacaOcorrencia}
+          onClose={() => setVacaOcorrencia(null)}
+          onSalvar={() => setVacaOcorrencia(null)}
         />
       )}
     </div>

--- a/src/pages/Reproducao/utilsReproducao.js
+++ b/src/pages/Reproducao/utilsReproducao.js
@@ -28,13 +28,7 @@ export const getStatusVaca = (del) => {
 export const getAcoesDisponiveis = (del) => {
   const ajustePEV = obterAjustePEV();
   if (del < ajustePEV) {
-    return [
-      'Registrar metrite',
-      'Registrar endometrite',
-      'Registrar infecção subclínica',
-      'Registrar cio natural (observação)',
-      'Iniciar pré-sincronização',
-    ];
+    return ['Registrar Ocorrência'];
   }
   return [
     'Iniciar Protocolo IATF',


### PR DESCRIPTION
## Summary
- compress PEV actions into a single *Registrar Ocorrência* option
- add modal to register clinical occurrence and optional treatment
- show modal from reproduction overview

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845bc51cb74832886cfbd871f928d32