### PR TITLE
Improve dashboard layout

### DIFF
--- a/src/pages/AppTarefas/DashboardAlertas.jsx
+++ b/src/pages/AppTarefas/DashboardAlertas.jsx
@@ -21,14 +21,27 @@ export default function DashboardAlertas() {
 
   if (alertas.length === 0) return null;
 
+  const definirEstilo = (msg) => {
+    const critico = /carência|pev|negativo/i.test(msg);
+    return critico
+      ? { cor: 'bg-red-500 text-white', icone: '\u{1F534}' }
+      : { cor: 'bg-yellow-400 text-black', icone: '\u{1F7E0}' };
+  };
+
   return (
-    <div className="bg-red-50 border border-red-200 rounded-xl p-4 shadow space-y-1">
-      {alertas.map((a, i) => (
-        <div key={i} className="flex items-center gap-2 text-sm text-red-800">
-          <span>❗</span>
-          <span>{a.mensagem}</span>
-        </div>
-      ))}
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+      {alertas.map((a, i) => {
+        const estilo = definirEstilo(a.mensagem);
+        return (
+          <div
+            key={i}
+            className={`flex items-center gap-2 p-3 rounded-xl shadow ${estilo.cor}`}
+          >
+            <span className="text-xl">{estilo.icone}</span>
+            <span className="text-sm md:text-base">{a.mensagem}</span>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/pages/AppTarefas/DashboardCards.jsx
+++ b/src/pages/AppTarefas/DashboardCards.jsx
@@ -12,19 +12,36 @@ export default function DashboardCards() {
   }, []);
 
   const cards = [
-    { cor: 'from-green-400 to-green-600', icone: '🐄', titulo: 'Vacas em lactação', valor: dados.lactacao },
-    { cor: 'from-yellow-400 to-yellow-600', icone: '⏳', titulo: 'Vacas em PEV', valor: dados.pev },
-    { cor: 'from-red-400 to-red-600', icone: '❌', titulo: 'Diagnóstico negativo', valor: dados.negativas },
-    { cor: 'from-purple-400 to-purple-600', icone: '🤰', titulo: 'Vacas em pré-parto', valor: dados.preParto },
+    {
+      cor: 'bg-green-500 text-white',
+      icone: '\u{1F7E2}',
+      titulo: 'Vacas em lactação',
+      valor: dados.lactacao,
+    },
+    {
+      cor: 'bg-orange-400 text-black',
+      icone: '\u{1F7E0}',
+      titulo: 'Vacas em PEV',
+      valor: dados.pev,
+    },
+    {
+      cor: 'bg-red-500 text-white',
+      icone: '\u{1F534}',
+      titulo: 'Diagnóstico negativo',
+      valor: dados.negativas,
+    },
+    {
+      cor: 'bg-blue-500 text-white',
+      icone: '\u{1F535}',
+      titulo: 'Vacas em pré-parto',
+      valor: dados.preParto,
+    },
   ];
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
       {cards.map((c, i) => (
-        <div
-          key={i}
-          className={`bg-gradient-to-r ${c.cor} text-white p-4 rounded-xl shadow-md flex justify-between items-center`}
-        >
+        <div key={i} className={`${c.cor} p-4 rounded-xl shadow-md flex justify-between items-center`}>
           <div>
             <p className="text-sm">{c.titulo}</p>
             <p className="text-2xl font-bold">{c.valor}</p>

--- a/src/pages/AppTarefas/index.jsx
+++ b/src/pages/AppTarefas/index.jsx
@@ -29,10 +29,22 @@ export default function AppTarefas() {
   };
 
   return (
-    <div className="p-4 space-y-4">
-      <DashboardAlertas />
-      <DashboardCards />
-      <DashboardGraficos />
+    <div className="p-4 space-y-6">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <section className="space-y-2">
+          <h2 className="font-bold border-b pb-1">🔔 Alertas Atuais</h2>
+          <DashboardAlertas />
+        </section>
+        <section className="space-y-2">
+          <h2 className="font-bold border-b pb-1">📊 Resumo do Rebanho</h2>
+          <DashboardCards />
+        </section>
+      </div>
+
+      <section className="space-y-2">
+        <h2 className="font-bold border-b pb-1">🧬 Diagnósticos Reprodutivos</h2>
+        <DashboardGraficos />
+      </section>
 
       <div className="flex flex-wrap gap-4">
         {[
@@ -51,7 +63,7 @@ export default function AppTarefas() {
       </div>
 
       <div className="bg-white rounded-xl shadow p-4">
-        <h3 className="font-bold mb-2">📅 Eventos de Hoje</h3>
+        <h3 className="font-bold mb-2 border-b pb-1">📅 Eventos de Hoje</h3>
         <ul className="space-y-1 mb-2">
           {eventos.map((ev, i) => (
             <li


### PR DESCRIPTION
## Summary
- redesign alert cards with severity detection and grid layout
- color-code dashboard summary cards
- reorganize task dashboard page with section headings

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68462012163c8328b3db8d461563abb2