### PR TITLE
Improve dashboard cards layout

### DIFF
--- a/src/pages/AppTarefas/index.jsx
+++ b/src/pages/AppTarefas/index.jsx
@@ -1,17 +1,18 @@
 import React, { useEffect, useState } from 'react';
+import { contagemStatusVacas } from './utilsDashboard';
 
 export default function AppTarefas() {
   const [alertas, setAlertas] = useState([]);
   const [resumo, setResumo] = useState({
-    lactacao: 4,
-    pev: 2,
-    negativos: 0,
-    preparto: 0,
-    carencias: 2,
+    lactacao: 0,
+    pev: 0,
+    negativas: 0,
+    preParto: 0,
+    carencias: 0,
   });
 
   useEffect(() => {
-    const atualizar = () => {
+    const atualizarAlertas = () => {
       const lista = JSON.parse(localStorage.getItem('alertasCarencia') || '[]');
       const hoje = new Date();
       const parse = (d) => {
@@ -26,75 +27,130 @@ export default function AppTarefas() {
       });
       localStorage.setItem('alertasCarencia', JSON.stringify(ativos));
       setAlertas(ativos);
+      setResumo((r) => ({ ...r, carencias: ativos.length }));
     };
 
-    atualizar();
-    window.addEventListener('alertasCarenciaAtualizados', atualizar);
-    return () => window.removeEventListener('alertasCarenciaAtualizados', atualizar);
+    const atualizarResumo = () => {
+      const dados = contagemStatusVacas();
+      setResumo((r) => ({ ...r, ...dados }));
+    };
+
+    atualizarAlertas();
+    atualizarResumo();
+    window.addEventListener('alertasCarenciaAtualizados', atualizarAlertas);
+    window.addEventListener('animaisAtualizados', atualizarResumo);
+    return () => {
+      window.removeEventListener('alertasCarenciaAtualizados', atualizarAlertas);
+      window.removeEventListener('animaisAtualizados', atualizarResumo);
+    };
   }, []);
 
   return (
-    <div className="p-6 grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-5">
+    <div style={{ padding: '2rem', fontFamily: 'Poppins, sans-serif' }}>
       {/* RESUMO */}
-      <ResumoCard titulo="🐄 Vacas em lactação" valor={resumo.lactacao} cor="green" />
-      <ResumoCard titulo="🧪 Vacas em PEV" valor={resumo.pev} cor="orange" />
-      <ResumoCard titulo="❌ Diagnóstico negativo" valor={resumo.negativos} cor="red" />
-      <ResumoCard titulo="🤰 Vacas em pré-parto" valor={resumo.preparto} cor="blue" />
-      <ResumoCard titulo="⚠️ Carência leite/carne" valor={resumo.carencias} cor="yellow" />
+      <div
+        style={{
+          display: 'flex',
+          gap: '1.5rem',
+          flexWrap: 'wrap',
+          justifyContent: 'center',
+        }}
+      >
+        <BlocoResumo titulo="Vacas em Lactação" valor={resumo.lactacao} icone="🐄" cor="#16a34a" />
+        <BlocoResumo titulo="Vacas em PEV" valor={resumo.pev} icone="🧪" cor="#f97316" />
+        <BlocoResumo titulo="Negativos" valor={resumo.negativas} icone="❌" cor="#dc2626" />
+        <BlocoResumo titulo="Pré-parto" valor={resumo.preParto} icone="🤰" cor="#2563eb" />
+        <BlocoResumo titulo="Carência leite/carne" valor={resumo.carencias} icone="⚠️" cor="#eab308" />
+      </div>
 
       {/* ALERTAS ATUAIS */}
-      <div className="col-span-full">
-        <h2 className="text-xl font-bold mt-6 mb-2">🔔 Alertas Atuais</h2>
-        {alertas.length === 0 && (
-          <div className="text-gray-500 italic">Nenhum alerta de carência no momento</div>
-        )}
-        {alertas.map((a, i) => (
-          <div
-            key={i}
-            className="bg-yellow-100 text-yellow-800 p-3 rounded-xl shadow flex items-center gap-2 mb-2"
-          >
-            ⚠️ Vaca {a.numeroAnimal} em carência de leite até {a.leiteAte || '-'} e carne até {a.carneAte || '-'}
-          </div>
-        ))}
+      <div style={{ marginTop: '2rem' }}>
+        <Card>
+          <h2 style={{ fontSize: '1.25rem', fontWeight: 700, marginBottom: '1rem' }}>
+            🔔 Alertas Atuais
+          </h2>
+          {alertas.length === 0 && (
+            <div style={{ color: '#6b7280', fontStyle: 'italic' }}>
+              Nenhum alerta de carência no momento
+            </div>
+          )}
+          {alertas.map((a, i) => (
+            <div
+              key={i}
+              style={{
+                backgroundColor: '#fef3c7',
+                padding: '1rem',
+                borderRadius: '1rem',
+                marginBottom: '0.5rem',
+                fontWeight: 600,
+                boxShadow: '0 0 10px rgba(0,0,0,0.05)',
+              }}
+            >
+              ⚠️ Vaca {a.numeroAnimal} em carência de leite até {a.leiteAte || '-'} e carne até{' '}
+              {a.carneAte || '-'}
+            </div>
+          ))}
+        </Card>
       </div>
 
       {/* DIAGNÓSTICOS */}
-      <div className="col-span-full mt-6">
-        <h2 className="text-xl font-bold mb-2">🧬 Diagnósticos Reprodutivos</h2>
-        <div className="bg-white rounded-xl shadow p-4 text-gray-700">
+      <div style={{ marginTop: '2rem' }}>
+        <Card>
+          <h2 style={{ fontSize: '1.25rem', fontWeight: 700, marginBottom: '1rem' }}>
+            🧬 Diagnósticos Reprodutivos
+          </h2>
           {/* Conteúdo futuro aqui */}
           Ainda não há diagnósticos lançados.
-        </div>
+        </Card>
       </div>
     </div>
   );
 }
 
-function ResumoCard({ titulo, valor, cor = 'gray' }) {
-  const corTexto = {
-    green: 'text-green-600',
-    red: 'text-red-600',
-    blue: 'text-blue-600',
-    yellow: 'text-yellow-600',
-    orange: 'text-orange-600',
-    gray: 'text-gray-600',
-  }[cor];
-
-  const corFundo = {
-    green: 'bg-green-50',
-    red: 'bg-red-50',
-    blue: 'bg-blue-50',
-    yellow: 'bg-yellow-50',
-    orange: 'bg-orange-50',
-    gray: 'bg-gray-100',
-  }[cor];
-
+function BlocoResumo({ titulo, valor, icone, cor }) {
   return (
     <div
-      className={`${corFundo} ${corTexto} rounded-2xl shadow-md p-4 hover:scale-105 transition-transform duration-200`}
+      style={{
+        backgroundColor: '#fff',
+        borderRadius: '1rem',
+        boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+        padding: '1.25rem',
+        flex: 1,
+        minWidth: '200px',
+        transition: 'transform 0.2s ease-in-out',
+        cursor: 'default',
+      }}
+      onMouseEnter={(e) => (e.currentTarget.style.transform = 'scale(1.03)')}
+      onMouseLeave={(e) => (e.currentTarget.style.transform = 'scale(1)')}
     >
-      <div className="text-sm mb-1">{titulo}</div>
-      <div className="text-3xl font-bold">{valor}</div>
+      <div
+        style={{
+          fontSize: '1.25rem',
+          color: cor || '#111827',
+          fontWeight: 700,
+        }}
+      >
+        {icone} {titulo}
+      </div>
+      <div style={{ fontSize: '2rem', fontWeight: 800 }}>{valor}</div>
+    </div>
+  );
+}
+
+function Card({ children }) {
+  return (
+    <div
+      style={{
+        backgroundColor: '#fff',
+        borderRadius: '1rem',
+        boxShadow: '0 10px 15px rgba(0,0,0,0.1)',
+        padding: '2rem',
+        transition: 'transform 0.2s ease-in-out',
+      }}
+      onMouseEnter={(e) => (e.currentTarget.style.transform = 'scale(1.03)')}
+      onMouseLeave={(e) => (e.currentTarget.style.transform = 'scale(1)')}
+    >
+      {children}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- modernize main dashboard layout
- compute summary info from localStorage utilities
- add card components using Poppins styling

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846323a98588328aa72fc50f592cefc