### PR TITLE
Adiciona componente CardLateral

### DIFF
--- a/src/pages/AppTarefas/componentes/CardLateral.jsx
+++ b/src/pages/AppTarefas/componentes/CardLateral.jsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export default function CardLateral({ children }) {
+  return (
+    <div
+      style={{
+        backgroundColor: '#fff',
+        borderRadius: '1rem',
+        boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+        padding: '1.5rem',
+        minWidth: '260px',
+        transition: 'transform 0.2s ease-in-out',
+      }}
+      onMouseEnter={(e) => (e.currentTarget.style.transform = 'scale(1.02)')}
+      onMouseLeave={(e) => (e.currentTarget.style.transform = 'scale(1)')}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/pages/AppTarefas/index.jsx
+++ b/src/pages/AppTarefas/index.jsx
@@ -4,6 +4,7 @@ import AlertasAtuais from './componentes/AlertasAtuais';
 import GraficosRepro from './componentes/GraficosRepro';
 import InsightsInteligentes from './componentes/InsightsInteligentes';
 import ResumoEstoqueCritico from './componentes/ResumoEstoqueCritico';
+import CardLateral from './componentes/CardLateral';
 
 export default function AppTarefas() {
   const [resumo, setResumo] = useState({
@@ -72,10 +73,18 @@ export default function AppTarefas() {
         <div className="flex-1">
           <AlertasAtuais />
         </div>
-        <div className="w-[300px] flex flex-col gap-4">
-          <ResumoEstoqueCritico />
-          <GraficosRepro />
-          <InsightsInteligentes />
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 mt-6">
+          <CardLateral>
+            <ResumoEstoqueCritico />
+          </CardLateral>
+
+          <CardLateral>
+            <GraficosRepro />
+          </CardLateral>
+
+          <CardLateral>
+            <InsightsInteligentes />
+          </CardLateral>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- criar componente `CardLateral` reutilizável
- aplicar `CardLateral` aos blocos laterais na página de tarefas

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e512306883288f0a4b4bed269d48