### PR TITLE
Integra painel de tarefas automático

### DIFF
--- a/src/pages/AppTarefas/TarefasCentrais.jsx
+++ b/src/pages/AppTarefas/TarefasCentrais.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import gerarTarefasAutomaticas from '../../utils/gerarTarefasAutomaticas';
 
 export default function AppTarefas() {
   const hoje = new Date().toISOString().slice(0, 10);
@@ -7,23 +8,37 @@ export default function AppTarefas() {
   const [mostrarHistorico, setMostrarHistorico] = useState(false);
 
   useEffect(() => {
-    const armazenadas = JSON.parse(localStorage.getItem('tarefas') || '[]');
-    const atualizadas = armazenadas.map((t) => {
-      if (t.status === 'pendente' && t.data < hoje) {
-        return { ...t, status: 'atrasado' };
-      }
-      return t;
-    });
+    const carregar = () => {
+      gerarTarefasAutomaticas();
+      let armazenadas = JSON.parse(localStorage.getItem('tarefas') || '[]');
+      const atualizadas = armazenadas.map((t) => {
+        if (t.status === 'pendente' && t.data < hoje && t.tipo !== 'estoque') {
+          return { ...t, status: 'atrasado' };
+        }
+        return t;
+      });
 
-    const agrupadas = {};
-    atualizadas.forEach((t) => {
-      if (!agrupadas[t.data]) agrupadas[t.data] = [];
-      agrupadas[t.data].push(t);
-    });
+      const agrupadas = {};
+      atualizadas.forEach((t) => {
+        if (!agrupadas[t.data]) agrupadas[t.data] = [];
+        agrupadas[t.data].push(t);
+      });
 
-    setTarefas(agrupadas[hoje] || []);
-    setHistorico(agrupadas);
-    localStorage.setItem('tarefas', JSON.stringify(atualizadas));
+      setTarefas(agrupadas[hoje] || []);
+      setHistorico(agrupadas);
+      localStorage.setItem('tarefas', JSON.stringify(atualizadas));
+    };
+
+    carregar();
+    const eventos = [
+      'manejosSanitariosAtualizados',
+      'tratamentosAtualizados',
+      'produtosAtualizados',
+      'alertasCarenciaAtualizados',
+      'eventosExtrasAtualizados',
+    ];
+    eventos.forEach((ev) => window.addEventListener(ev, carregar));
+    return () => eventos.forEach((ev) => window.removeEventListener(ev, carregar));
   }, []);
 
   const atualizarStorage = (novas) => {
@@ -69,7 +84,7 @@ export default function AppTarefas() {
         boxShadow: '0 10px 15px rgba(0,0,0,0.1)',
         padding: '2rem',
         width: '100%',
-        maxWidth: '420px',
+        maxWidth: '680px',
         border: '1px solid #e2e8f0'
       }}>
         <h2 style={{
@@ -111,7 +126,7 @@ export default function AppTarefas() {
                 color: t.status === 'feito' ? '#9ca3af' : '#111827',
                 fontWeight: '600'
               }}>{t.descricao}</span>
-              {t.status !== 'feito' && (
+              {t.status !== 'feito' && t.tipo !== 'estoque' && (
                 <button onClick={() => marcarComoConcluida(t.id)} style={{
                   backgroundColor: '#3b82f6',
                   color: '#fff',
@@ -170,7 +185,7 @@ export default function AppTarefas() {
                         fontWeight: '600'
                       }}>
                         <span>{t.status === 'feito' ? '✅' : '❌'} {t.descricao}</span>
-                        {t.status === 'pendente' && (
+                        {t.status === 'pendente' && t.tipo !== 'estoque' && (
                           <button onClick={() => remarcarTarefa(data, t)} style={{
                             marginLeft: '0.5rem',
                             backgroundColor: '#f59e0b',

--- a/src/utils/gerarTarefasAutomaticas.js
+++ b/src/utils/gerarTarefasAutomaticas.js
@@ -1,0 +1,73 @@
+import verificarAlertaEstoque from './verificarAlertaEstoque';
+import { eventosDeHoje } from '../pages/AppTarefas/utilsDashboard';
+
+function parseData(data) {
+  if (!data) return null;
+  if (data.includes('-')) return new Date(data);
+  const [d, m, y] = data.split('/');
+  if (!d || !m || !y) return null;
+  return new Date(y, m - 1, d);
+}
+
+export default function gerarTarefasAutomaticas() {
+  const hojeISO = new Date().toISOString().slice(0, 10);
+  const hoje = new Date(hojeISO);
+  let tarefas = JSON.parse(localStorage.getItem('tarefas') || '[]');
+
+  const adicionar = (id, descricao, tipo) => {
+    if (!tarefas.some((t) => t.id === id)) {
+      tarefas.push({ id, data: hojeISO, descricao, tipo, status: 'pendente' });
+    }
+  };
+
+  // Tratamentos registrados
+  const tratamentos = JSON.parse(localStorage.getItem('tratamentos') || '[]');
+  tratamentos.forEach((tr, idx) => {
+    const inicio = parseData(tr.dataInicio || tr.data);
+    if (!inicio) return;
+    const dur = parseInt(tr.duracao) || 1;
+    for (let i = 0; i < dur; i++) {
+      const d = new Date(inicio);
+      d.setDate(d.getDate() + i);
+      if (d.toDateString() === hoje.toDateString()) {
+        const id = `trat-${idx}-${i}-${hojeISO}`;
+        adicionar(id, `Aplicar ${tr.produto} na Vaca ${tr.numeroAnimal}`, 'tratamento');
+      }
+    }
+  });
+
+  // Alertas de carência
+  const carencias = JSON.parse(localStorage.getItem('alertasCarencia') || '[]');
+  carencias.forEach((c, idx) => {
+    const leite = parseData(c.leiteAte);
+    const carne = parseData(c.carneAte);
+    if (leite && leite >= hoje) {
+      const id = `car-leite-${c.numeroAnimal}-${idx}-${hojeISO}`;
+      adicionar(id, `Carência da Vaca ${c.numeroAnimal} até ${c.leiteAte} (leite)`, 'carencia');
+    }
+    if (carne && carne >= hoje) {
+      const id = `car-carne-${c.numeroAnimal}-${idx}-${hojeISO}`;
+      adicionar(id, `Carência da Vaca ${c.numeroAnimal} até ${c.carneAte} (carne)`, 'carencia');
+    }
+  });
+
+  // Alertas de estoque
+  const produtos = JSON.parse(localStorage.getItem('produtos') || '[]');
+  produtos.forEach((p) => {
+    const alerta = verificarAlertaEstoque(p);
+    const id = `estoque-${p.nomeComercial}`;
+    if (alerta.status !== 'ok') {
+      adicionar(id, `Comprar mais ${p.nomeComercial} (Estoque Crítico)`, 'estoque');
+    } else {
+      tarefas = tarefas.filter((t) => t.id !== id);
+    }
+  });
+
+  // Eventos do dia (partos, vacinas etc.)
+  eventosDeHoje().forEach((ev, i) => {
+    const id = `evento-${i}-${hojeISO}`;
+    adicionar(id, ev.title, 'evento');
+  });
+
+  localStorage.setItem('tarefas', JSON.stringify(tarefas));
+}


### PR DESCRIPTION
## Summary
- gerar tarefas automaticamente a partir de dados do sistema
- atualizar painel central para ler essas tarefas e aumentar a largura do card
- impedir conclusão ou remarcar de tarefas de estoque

## Testing
- `npm run build` *(falhou: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68470c90f77c8328a259961f1b85f821