### PR TITLE
Finalize reproductive protocol module

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,12 @@
 import SistemaBase from './layout/SistemaBase';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 function App() {
   return (
     <>
-
       <SistemaBase />
+      <ToastContainer position="bottom-right" autoClose={3000} hideProgressBar={false} pauseOnHover theme="light" />
     </>
   );
 }

--- a/src/pages/Reproducao/ModalCadastroProtocolo.jsx
+++ b/src/pages/Reproducao/ModalCadastroProtocolo.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from "react";
 import Select from "react-select";
+import { toast } from "react-toastify";
 import "../../styles/modalPadrao.css";
 
 const hormonios = [
@@ -11,12 +12,25 @@ const hormonios = [
   { id: "hCG", nome: "hCG" },
 ];
 
-export default function ModalCadastroProtocolo({ onFechar, onSalvar }) {
+export default function ModalCadastroProtocolo({ onFechar, onSalvar, protocoloInicial = null, indiceEdicao = null }) {
   const diasIniciais = Array.from({ length: 11 }, (_, i) => i);
-  const [nome, setNome] = useState("");
-  const [descricao, setDescricao] = useState("");
-  const [dias, setDias] = useState(diasIniciais);
-  const [etapas, setEtapas] = useState({});
+  const [nome, setNome] = useState(protocoloInicial?.nome || "");
+  const [descricao, setDescricao] = useState(protocoloInicial?.descricao || "");
+  const [dias, setDias] = useState(
+    protocoloInicial
+      ? Array.from(new Set(protocoloInicial.etapas.map((e) => e.dia))).sort((a, b) => a - b)
+      : diasIniciais
+  );
+  const [etapas, setEtapas] = useState(
+    protocoloInicial
+      ? protocoloInicial.etapas.reduce((acc, e) => {
+          const { hormonio = "", acao = "", dia } = e;
+          if (!acc[dia]) acc[dia] = [];
+          acc[dia].push({ hormonio, acao });
+          return acc;
+        }, {})
+      : {}
+  );
   const [formDia, setFormDia] = useState(null);
   const [formIndex, setFormIndex] = useState(null);
   const [form, setForm] = useState({
@@ -128,9 +142,15 @@ export default function ModalCadastroProtocolo({ onFechar, onSalvar }) {
       etapas: etapasList.sort((a, b) => a.dia - b.dia),
     };
     const salvos = JSON.parse(localStorage.getItem("protocolos") || "[]");
-    localStorage.setItem("protocolos", JSON.stringify([...salvos, protocolo]));
+    if (indiceEdicao !== null) {
+      salvos[indiceEdicao] = protocolo;
+    } else {
+      salvos.push(protocolo);
+    }
+    localStorage.setItem("protocolos", JSON.stringify(salvos));
     localStorage.removeItem("cadastroProtocoloTmp");
     onSalvar && onSalvar(protocolo);
+    toast.success("✅ Protocolo salvo com sucesso!");
     onFechar();
   };
 
@@ -157,15 +177,16 @@ export default function ModalCadastroProtocolo({ onFechar, onSalvar }) {
   };
 
   const headerStyle = {
-    backgroundColor: "#004AAD",
+    backgroundColor: "#1F3FB6",
     color: "white",
-    fontWeight: "bold",
-    padding: "10px 20px",
+    padding: "12px 24px",
     fontSize: "16px",
-    display: "flex",
-    alignItems: "center",
+    fontWeight: 600,
     borderTopLeftRadius: "12px",
     borderTopRightRadius: "12px",
+    display: "flex",
+    alignItems: "center",
+    gap: "8px",
   };
 
   const headerInput = {
@@ -187,7 +208,10 @@ export default function ModalCadastroProtocolo({ onFechar, onSalvar }) {
   return (
     <div style={overlay} onClick={onFechar}>
       <div style={modal} onClick={(e) => e.stopPropagation()} className="modal-content">
-        <div style={headerStyle}>🧬 Cadastrar Protocolo IATF</div>
+        <div style={headerStyle}>
+          <span>🧬</span>
+          <span>Cadastrar Protocolo IATF</span>
+        </div>
         <div className="sticky top-0 bg-white pb-2">
           <label>Nome do Protocolo:</label>
           <input

--- a/src/pages/Reproducao/ProtocolosReprodutivos.jsx
+++ b/src/pages/Reproducao/ProtocolosReprodutivos.jsx
@@ -6,6 +6,7 @@ import "../../styles/botoes.css";
 
 export default function ProtocolosReprodutivos() {
   const [modalAberto, setModalAberto] = useState(false);
+  const [indexEditar, setIndexEditar] = useState(null);
   const [protocolos, setProtocolos] = useState([]);
   const [colunaHover, setColunaHover] = useState(null);
   const [protocoloExpandido, setProtocoloExpandido] = useState(null);
@@ -16,8 +17,13 @@ export default function ProtocolosReprodutivos() {
     setProtocolos(salvos);
   }, []);
 
-  const salvarProtocolo = (novoProtocolo) => {
-    const atualizados = [...protocolos, novoProtocolo];
+  const salvarProtocolo = (prot, indice = null) => {
+    let atualizados = [];
+    if (indice !== null) {
+      atualizados = protocolos.map((p, i) => (i === indice ? prot : p));
+    } else {
+      atualizados = [...protocolos, prot];
+    }
     setProtocolos(atualizados);
     localStorage.setItem("protocolos", JSON.stringify(atualizados));
   };
@@ -30,7 +36,8 @@ export default function ProtocolosReprodutivos() {
   };
 
   const editarProtocolo = (index) => {
-    alert("Funcionalidade de edição em desenvolvimento. Index: " + index);
+    setIndexEditar(index);
+    setModalAberto(true);
   };
 
   const toggleExpandirProtocolo = (index) => {
@@ -45,9 +52,9 @@ export default function ProtocolosReprodutivos() {
       return acc;
     }, {});
     return Object.entries(agrupado).map(([dia, itens]) => (
-      <div key={dia} style={{ marginBottom: "4px" }}>
+      <div key={dia} style={{ marginBottom: "8px" }}>
         <div style={{ fontWeight: 600 }}>Dia {dia}:</div>
-        <ul className="list-disc ml-5">
+        <ul className="list-disc ml-4" style={{ wordBreak: "break-word" }}>
           {itens.map((it, idx) => (
             <li key={idx}>{it}</li>
           ))}
@@ -62,7 +69,10 @@ export default function ProtocolosReprodutivos() {
     <div className="w-full px-8 py-6 font-sans">
       <div style={{ marginBottom: "1rem", textAlign: "right" }}>
         <button
-          onClick={() => setModalAberto(true)}
+          onClick={() => {
+            setIndexEditar(null);
+            setModalAberto(true);
+          }}
           className="botao-acao"
         >
           ➕ Cadastrar Protocolo
@@ -101,8 +111,8 @@ export default function ProtocolosReprodutivos() {
                   <td className={colunaHover === 1 ? "coluna-hover" : ""}>
                     {protocolo.descricao || "—"}
                   </td>
-                  <td className={colunaHover === 2 ? "coluna-hover" : ""}>
-                    <div style={{ backgroundColor: "#eaf3ff", padding: "8px", borderRadius: "8px" }}>
+                  <td className={colunaHover === 2 ? "coluna-hover" : ""} style={{ whiteSpace: "normal", overflow: "visible" }}>
+                    <div style={{ backgroundColor: "#eaf3ff", padding: "12px 16px", borderRadius: "8px", fontSize: "14px" }}>
                       <div style={{ fontWeight: 600, color: "#004AAD" }}>Etapas:</div>
                       {formatarEtapas(protocolo.etapas)}
                     </div>
@@ -148,8 +158,17 @@ export default function ProtocolosReprodutivos() {
 
       {modalAberto && (
         <ModalCadastroProtocolo
-          onFechar={() => setModalAberto(false)}
-          onSalvar={salvarProtocolo}
+          onFechar={() => {
+            setModalAberto(false);
+            setIndexEditar(null);
+          }}
+          onSalvar={(p) => {
+            salvarProtocolo(p, indexEditar);
+            setModalAberto(false);
+            setIndexEditar(null);
+          }}
+          protocoloInicial={indexEditar !== null ? protocolos[indexEditar] : null}
+          indiceEdicao={indexEditar}
         />
       )}
 


### PR DESCRIPTION
## Summary
- add ToastContainer globally
- load modal with existing protocol data when editing
- allow editing and saving of protocols
- style IATF protocol header consistently
- display protocol steps with better formatting

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a2ccac4ec8328b208440f58ac02b3