### PR TITLE
Fix protocol type filter

### DIFF
--- a/src/pages/Reproducao/ModalCadastroProtocolo.jsx
+++ b/src/pages/Reproducao/ModalCadastroProtocolo.jsx
@@ -16,7 +16,9 @@ export default function ModalCadastroProtocolo({ onFechar, onSalvar, protocoloIn
   const diasIniciais = Array.from({ length: 11 }, (_, i) => i);
   const [nome, setNome] = useState(protocoloInicial?.nome || "");
   const [descricao, setDescricao] = useState(protocoloInicial?.descricao || "");
-  const [tipo, setTipo] = useState(protocoloInicial?.tipo || "IATF");
+  const [tipo, setTipo] = useState(
+    protocoloInicial?.tipo?.toUpperCase() || "IATF"
+  );
   const [dias, setDias] = useState(
     protocoloInicial
       ? Array.from(new Set(protocoloInicial.etapas.map((e) => e.dia))).sort((a, b) => a - b)
@@ -218,11 +220,11 @@ export default function ModalCadastroProtocolo({ onFechar, onSalvar, protocoloIn
           <label>Tipo do Protocolo:</label>
           <select
             value={tipo}
-            onChange={(e) => setTipo(e.target.value)}
+            onChange={(e) => setTipo(e.target.value.toUpperCase())}
             style={headerInput}
           >
             <option value="IATF">IATF</option>
-            <option value="Pré-sincronização">Pré-sincronização</option>
+            <option value="PRÉ-SINCRONIZAÇÃO">Pré-sincronização</option>
           </select>
           <label>Nome do Protocolo:</label>
           <input

--- a/src/pages/Reproducao/ModalRegistrarOcorrencia.jsx
+++ b/src/pages/Reproducao/ModalRegistrarOcorrencia.jsx
@@ -43,10 +43,15 @@ export default function ModalRegistrarOcorrencia({ vaca, status = 'No PEV', onCl
   const [protocoloSelecionado, setProtocoloSelecionado] = useState(null);
   const camposRef = useRef([]);
 
+  const tipoEsperado =
+    tipo === 'Iniciar Protocolo IATF'
+      ? 'IATF'
+      : tipo === 'Iniciar Pré-sincronização'
+      ? 'PRÉ-SINCRONIZAÇÃO'
+      : '';
+
   const protocolosFiltrados = todosProtocolos.filter((p) => {
-    if (tipo === 'Iniciar Protocolo IATF') return p.tipo === 'IATF';
-    if (tipo === 'Iniciar Pré-sincronização') return p.tipo === 'Pré-sincronização';
-    return false;
+    return (p.tipo || '').toUpperCase() === tipoEsperado;
   });
 
   const handleEnter = (index) => (e) => {
@@ -179,7 +184,7 @@ export default function ModalRegistrarOcorrencia({ vaca, status = 'No PEV', onCl
       const prot = todosProtocolos.find(p => p.id === protocoloSelecionado.value);
       historico.push({
         protocolo: protocoloSelecionado.label,
-        tipo: prot?.tipo || (tipo.includes('IATF') ? 'IATF' : 'Pré-sincronização'),
+        tipo: (prot?.tipo || (tipo.includes('IATF') ? 'IATF' : 'PRÉ-SINCRONIZAÇÃO')).toUpperCase(),
         dataInicio: dataOcorrencia
       });
       localStorage.setItem(historicoKey, JSON.stringify(historico));


### PR DESCRIPTION
## Summary
- normalize protocol type on creation
- filter protocols case-insensitively when registering occurrences
- store protocol type in history with uppercase value

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b2bb9dce08328a8666588faeea4b6