### PR TITLE
Connect reproductive events to protocol overview

### DIFF
--- a/src/pages/Animais/FichaAnimalReproducao.jsx
+++ b/src/pages/Animais/FichaAnimalReproducao.jsx
@@ -8,6 +8,7 @@ import GraficoIAPorCiclo from "./GraficoIAPorCiclo";
 import LinhaDoTempoReprodutiva from "./LinhaDoTempoReprodutiva";
 import { calcularDELPorCiclo } from "./utilsAnimais";
 import FichaAnimalResumoReprodutivo from "./FichaAnimalResumoReprodutivo";
+import { carregarRegistro } from "../../utils/registroReproducao";
 
 export default function FichaAnimalReproducao({ animal }) {
   const hoje = new Date();
@@ -131,6 +132,10 @@ export default function FichaAnimalReproducao({ animal }) {
       (ciclo.secagens || []).forEach((s) => {
         if (s?.data) eventos.push({ tipo: "Secagem", data: s.data, subtipo: s.subtipo || "", obs: s.obs || "—" });
       });
+    });
+    const regs = carregarRegistro(animal.numero);
+    regs.forEach(r => {
+      eventos.push({ tipo: r.tipo, data: r.data, subtipo: r.nomeProtocolo || "", obs: r.obs || "—" });
     });
     return eventos.sort((a, b) => new Date(a.data.split("/").reverse().join("-")) - new Date(b.data.split("/").reverse().join("-")));
   }, [animal, ciclosEditados, ciclos]);

--- a/src/pages/Reproducao/ModalRegistrarOcorrencia.jsx
+++ b/src/pages/Reproducao/ModalRegistrarOcorrencia.jsx
@@ -4,6 +4,10 @@ import { addDays } from 'date-fns';
 import { toast } from 'react-toastify';
 import { formatarDataDigitada, formatarDataBR } from '../Animais/utilsAnimais';
 import { addEventoCalendario } from '../../utils/eventosCalendario';
+import {
+  adicionarOcorrencia,
+  calcularProximaEtapa
+} from '../../utils/registroReproducao';
 
 export default function ModalRegistrarOcorrencia({ vaca, status = 'No PEV', onClose, onSalvar }) {
   const TIPOS_PEV = [
@@ -103,6 +107,12 @@ export default function ModalRegistrarOcorrencia({ vaca, status = 'No PEV', onCl
     localStorage.setItem('ocorrencias', JSON.stringify(listaOc));
     window.dispatchEvent(new Event('ocorrenciasAtualizadas'));
 
+    const registro = {
+      tipo,
+      data: dataOcorrencia,
+      obs: observacoes
+    };
+
     if (iniciarTratamento && produto && dataInicioTratamento) {
       const tratamento = {
         numeroAnimal: vaca.numero,
@@ -197,9 +207,14 @@ export default function ModalRegistrarOcorrencia({ vaca, status = 'No PEV', onCl
           const titulo = et.hormonio || et.acao || 'Etapa';
           addEventoCalendario({ title: `${titulo} - Vaca ${vaca.numero}`, date: data, tipo: 'protocolo' });
         });
+        registro.protocoloId = prot.id;
+        registro.nomeProtocolo = prot.nome;
+        registro.proximaEtapa = calcularProximaEtapa(prot, dataOcorrencia);
       }
       toast.success('Protocolo aplicado com sucesso!');
     }
+
+    adicionarOcorrencia(vaca.numero, registro);
 
     onSalvar?.(ocorrencia);
     onClose?.();

--- a/src/pages/Reproducao/ProtocolosReprodutivos.jsx
+++ b/src/pages/Reproducao/ProtocolosReprodutivos.jsx
@@ -3,6 +3,7 @@ import ModalCadastroProtocolo from "./ModalCadastroProtocolo";
 import ModalConfirmarExclusao from "../../components/ModalConfirmarExclusao";
 import "../../styles/tabelaModerna.css";
 import "../../styles/botoes.css";
+import { listarAnimaisPorProtocolo } from "../../utils/registroReproducao";
 
 export default function ProtocolosReprodutivos() {
   const [modalAberto, setModalAberto] = useState(false);
@@ -11,6 +12,7 @@ export default function ProtocolosReprodutivos() {
   const [colunaHover, setColunaHover] = useState(null);
   const [protocoloExpandido, setProtocoloExpandido] = useState(null);
   const [protocoloExcluir, setProtocoloExcluir] = useState(null);
+  const [vacasPorProtocolo, setVacasPorProtocolo] = useState({});
 
   useEffect(() => {
     const salvos = JSON.parse(localStorage.getItem("protocolos") || "[]");
@@ -41,7 +43,17 @@ export default function ProtocolosReprodutivos() {
   };
 
   const toggleExpandirProtocolo = (index) => {
-    setProtocoloExpandido(protocoloExpandido === index ? null : index);
+    if (protocoloExpandido === index) {
+      setProtocoloExpandido(null);
+    } else {
+      setProtocoloExpandido(index);
+      const prot = protocolos[index];
+      if (prot) {
+        const idProt = prot.id ?? index;
+        const vacas = listarAnimaisPorProtocolo(idProt);
+        setVacasPorProtocolo(v => ({ ...v, [idProt]: vacas }));
+      }
+    }
   };
 
   const formatarEtapas = (lista) => {
@@ -140,7 +152,7 @@ export default function ProtocolosReprodutivos() {
                         onClick={() => toggleExpandirProtocolo(index)}
                         className="botao-acao pequeno"
                       >
-                        {protocoloExpandido === index ? "🔼" : "🔽"}
+                        {protocoloExpandido === index ? "🔼 Ocultar" : "🔽 Ver Vacas"}
                       </button>
                     </div>
                   </td>
@@ -148,8 +160,22 @@ export default function ProtocolosReprodutivos() {
 
                 {protocoloExpandido === index && (
                   <tr>
-                    <td colSpan={5} className="bg-gray-50 p-2 text-sm text-center text-gray-500">
-                      Nenhum animal ativo listado para este protocolo.
+                    <td colSpan={5} className="bg-gray-50 p-2 text-sm">
+                      {(
+                        vacasPorProtocolo[protocolo.id ?? index] || []
+                      ).length === 0 ? (
+                        <div className="text-center text-gray-500">
+                          Nenhum animal ativo listado para este protocolo.
+                        </div>
+                      ) : (
+                        <ul className="list-disc ml-4 space-y-1">
+                          {vacasPorProtocolo[protocolo.id ?? index].map((v) => (
+                            <li key={v.numero}>
+                              #{v.numero} - iniciado em {v.dataInicio || '—'}
+                            </li>
+                          ))}
+                        </ul>
+                      )}
                     </td>
                   </tr>
                 )}

--- a/src/pages/Reproducao/VisaoGeralReproducao.jsx
+++ b/src/pages/Reproducao/VisaoGeralReproducao.jsx
@@ -6,6 +6,7 @@ import { getStatusVaca, filtrarAnimaisAtivos, filtrarPorStatus } from './utilsRe
 import ModalRegistrarOcorrencia from './ModalRegistrarOcorrencia';
 import '../../styles/tabelaModerna.css';
 import '../../styles/botoes.css';
+import { carregarRegistro } from '../../utils/registroReproducao';
 
 export default function VisaoGeralReproducao() {
   const [vacas, setVacas] = useState([]);
@@ -26,7 +27,18 @@ export default function VisaoGeralReproducao() {
 
   useEffect(() => {
     const animais = carregarAnimaisDoLocalStorage();
-    const ativos = filtrarAnimaisAtivos(animais);
+    const ativos = filtrarAnimaisAtivos(animais).map(a => {
+      const registro = carregarRegistro(a.numero);
+      if (registro.length) {
+        const ultimo = registro[registro.length - 1];
+        a.ultimaAcao = { tipo: ultimo.tipo, data: ultimo.data };
+        if (ultimo.proximaEtapa) a.proximaAcao = {
+          tipo: ultimo.proximaEtapa.nome,
+          dataPrevista: ultimo.proximaEtapa.data
+        };
+      }
+      return a;
+    });
     setVacas(ativos);
 
     const config = JSON.parse(localStorage.getItem("configPEV") || "{}");

--- a/src/utils/registroReproducao.js
+++ b/src/utils/registroReproducao.js
@@ -1,0 +1,44 @@
+import { addDays } from 'date-fns';
+import { formatarDataBR } from '../pages/Animais/utilsAnimais';
+
+export function carregarRegistro(numero) {
+  return JSON.parse(localStorage.getItem(`registroReprodutivo_${numero}`) || '[]');
+}
+
+export function salvarRegistro(numero, dados) {
+  localStorage.setItem(`registroReprodutivo_${numero}`, JSON.stringify(dados));
+}
+
+export function adicionarOcorrencia(numero, ocorrencia) {
+  const dados = carregarRegistro(numero);
+  dados.push(ocorrencia);
+  salvarRegistro(numero, dados);
+  window.dispatchEvent(new Event('registroReprodutivoAtualizado'));
+}
+
+export function calcularProximaEtapa(protocolo, inicio) {
+  if (!protocolo || !inicio) return null;
+  const [d, m, a] = inicio.split('/');
+  const dataBase = new Date(`${a}-${m}-${d}`);
+  const hoje = new Date();
+  const etapas = protocolo.etapas.sort((a, b) => a.dia - b.dia);
+  for (const et of etapas) {
+    const data = addDays(dataBase, et.dia);
+    if (data >= hoje) {
+      const nome = et.hormonio || et.acao || 'Etapa';
+      return { nome, data: formatarDataBR(data) };
+    }
+  }
+  return null;
+}
+
+export function listarAnimaisPorProtocolo(protocolId) {
+  if (!protocolId) return [];
+  const animais = JSON.parse(localStorage.getItem('animais') || '[]');
+  return animais.reduce((acc, a) => {
+    const regs = carregarRegistro(a.numero);
+    const r = regs.find(t => t.protocoloId === protocolId && !t.concluido);
+    if (r) acc.push({ numero: a.numero, dataInicio: r.data });
+    return acc;
+  }, []);
+}


### PR DESCRIPTION
## Summary
- store reproductive events under `registroReprodutivo_<numero>`
- update occurrence modal to save protocol info and calculate next step
- show last and next actions in reproduction overview
- list active cows per protocol
- include reproductive occurrences on the animal timeline

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b3070c83c83288512d6a07076b93f