### PR TITLE
Fix reproductive protocol records

### DIFF
--- a/src/pages/Animais/FichaAnimalReproducao.jsx
+++ b/src/pages/Animais/FichaAnimalReproducao.jsx
@@ -133,12 +133,16 @@ export default function FichaAnimalReproducao({ animal }) {
         if (s?.data) eventos.push({ tipo: "Secagem", data: s.data, subtipo: s.subtipo || "", obs: s.obs || "—" });
       });
     });
-    const regs = carregarRegistro(animal.numero);
+    const regs = carregarRegistro(animal.numero).ocorrencias || [];
     regs.forEach(r => {
       eventos.push({ tipo: r.tipo, data: r.data, subtipo: r.nomeProtocolo || "", obs: r.obs || "—" });
     });
     return eventos.sort((a, b) => new Date(a.data.split("/").reverse().join("-")) - new Date(b.data.split("/").reverse().join("-")));
   }, [animal, ciclosEditados, ciclos]);
+
+  const registroOcorrencias = useMemo(() => {
+    return carregarRegistro(animal.numero).ocorrencias || [];
+  }, [animal]);
 
   return (
     <div>
@@ -201,6 +205,32 @@ export default function FichaAnimalReproducao({ animal }) {
             </div>
           );
         })}
+
+        {registroOcorrencias.length > 0 && (
+          <div style={{ marginTop: '2rem' }}>
+            <h4 style={{ color: '#1e40af', marginBottom: '0.5rem' }}>📑 Ocorrências Reprodutivas</h4>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '14px' }}>
+              <thead>
+                <tr style={{ background: '#f0f0f0' }}>
+                  <th>Data</th>
+                  <th>Evento</th>
+                  <th>Protocolo</th>
+                  <th>Observações</th>
+                </tr>
+              </thead>
+              <tbody>
+                {registroOcorrencias.map((o, idx) => (
+                  <tr key={`reg-${idx}`}>
+                    <td>{o.data}</td>
+                    <td>{o.tipo}</td>
+                    <td>{o.nomeProtocolo || '–'}</td>
+                    <td>{o.obs || '–'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/pages/Animais/ModalHistoricoCompleto.jsx
+++ b/src/pages/Animais/ModalHistoricoCompleto.jsx
@@ -28,6 +28,8 @@ export default function ModalHistoricoCompleto({ animal, onClose }) {
   useEffect(() => {
     const p = JSON.parse(localStorage.getItem('pesagens') || '[]');
     const o = JSON.parse(localStorage.getItem('ocorrencias') || '[]');
+    const registro = JSON.parse(localStorage.getItem(`registroReprodutivo_${animal.numero}`) || '{}');
+    const ocorrProt = registro.ocorrencias || [];
     const t = JSON.parse(localStorage.getItem('tratamentos') || '[]');
     const l = JSON.parse(localStorage.getItem('leite') || '[]');
     const pts = JSON.parse(localStorage.getItem('partos') || '[]');
@@ -38,7 +40,7 @@ export default function ModalHistoricoCompleto({ animal, onClose }) {
     const filtrar = (arr) => arr.filter((ev) => ev.numeroAnimal === animal.numero);
 
     setPesagens(filtrar(p));
-    setOcorrencias(filtrar(o));
+    setOcorrencias(ocorrProt);
     setTratamentos(filtrar(t));
     setInseminacoes(filtrar(ias));
     setDiagnosticos(filtrar(dxs));

--- a/src/pages/Reproducao/ModalRegistrarOcorrencia.jsx
+++ b/src/pages/Reproducao/ModalRegistrarOcorrencia.jsx
@@ -108,7 +108,7 @@ export default function ModalRegistrarOcorrencia({ vaca, status = 'No PEV', onCl
     window.dispatchEvent(new Event('ocorrenciasAtualizadas'));
 
     const registro = {
-      tipo,
+      tipo: tipo.startsWith('Iniciar ') ? `Início ${tipo.slice(8)}` : tipo,
       data: dataOcorrencia,
       obs: observacoes
     };
@@ -199,18 +199,19 @@ export default function ModalRegistrarOcorrencia({ vaca, status = 'No PEV', onCl
       });
       localStorage.setItem(historicoKey, JSON.stringify(historico));
 
-      if (prot) {
-        const [d, m, a] = dataOcorrencia.split('/');
-        const inicio = new Date(`${a}-${m}-${d}`);
-        prot.etapas.forEach(et => {
-          const data = addDays(inicio, et.dia).toISOString().split('T')[0];
-          const titulo = et.hormonio || et.acao || 'Etapa';
-          addEventoCalendario({ title: `${titulo} - Vaca ${vaca.numero}`, date: data, tipo: 'protocolo' });
-        });
-        registro.protocoloId = prot.id;
-        registro.nomeProtocolo = prot.nome;
-        registro.proximaEtapa = calcularProximaEtapa(prot, dataOcorrencia);
-      }
+        if (prot) {
+          const [d, m, a] = dataOcorrencia.split('/');
+          const inicio = new Date(`${a}-${m}-${d}`);
+          prot.etapas.forEach(et => {
+            const data = addDays(inicio, et.dia).toISOString().split('T')[0];
+            const titulo = et.hormonio || et.acao || 'Etapa';
+            addEventoCalendario({ title: `${titulo} - Vaca ${vaca.numero}`, date: data, tipo: 'protocolo' });
+          });
+          registro.protocoloId = prot.id;
+          registro.nomeProtocolo = prot.nome;
+          registro.etapas = prot.etapas;
+          registro.proximaEtapa = calcularProximaEtapa(prot, dataOcorrencia);
+        }
       toast.success('Protocolo aplicado com sucesso!');
     }
 

--- a/src/pages/Reproducao/ProtocolosReprodutivos.jsx
+++ b/src/pages/Reproducao/ProtocolosReprodutivos.jsx
@@ -168,13 +168,26 @@ export default function ProtocolosReprodutivos() {
                           Nenhum animal ativo listado para este protocolo.
                         </div>
                       ) : (
-                        <ul className="list-disc ml-4 space-y-1">
-                          {vacasPorProtocolo[protocolo.id ?? index].map((v) => (
-                            <li key={v.numero}>
-                              #{v.numero} - iniciado em {v.dataInicio || '—'}
-                            </li>
-                          ))}
-                        </ul>
+                        <table className="w-full text-left border border-gray-200 mt-1">
+                          <thead>
+                            <tr className="bg-gray-100">
+                              <th className="px-2 py-1">Número</th>
+                              <th className="px-2 py-1">Nome/Brinco</th>
+                              <th className="px-2 py-1">Data de início</th>
+                              <th className="px-2 py-1">Status</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            {vacasPorProtocolo[protocolo.id ?? index].map((v) => (
+                              <tr key={v.numero} className="odd:bg-white even:bg-gray-50">
+                                <td className="px-2 py-1">{v.numero}</td>
+                                <td className="px-2 py-1">{v.nome || '—'}</td>
+                                <td className="px-2 py-1">{v.dataInicio || '—'}</td>
+                                <td className="px-2 py-1">{v.status || '—'}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
                       )}
                     </td>
                   </tr>

--- a/src/pages/Reproducao/VisaoGeralReproducao.jsx
+++ b/src/pages/Reproducao/VisaoGeralReproducao.jsx
@@ -29,8 +29,9 @@ export default function VisaoGeralReproducao() {
     const animais = carregarAnimaisDoLocalStorage();
     const ativos = filtrarAnimaisAtivos(animais).map(a => {
       const registro = carregarRegistro(a.numero);
-      if (registro.length) {
-        const ultimo = registro[registro.length - 1];
+      const ocorr = registro.ocorrencias || [];
+      if (ocorr.length) {
+        const ultimo = ocorr[ocorr.length - 1];
         a.ultimaAcao = { tipo: ultimo.tipo, data: ultimo.data };
         if (ultimo.proximaEtapa) a.proximaAcao = {
           tipo: ultimo.proximaEtapa.nome,

--- a/src/utils/registroReproducao.js
+++ b/src/utils/registroReproducao.js
@@ -2,7 +2,15 @@ import { addDays } from 'date-fns';
 import { formatarDataBR } from '../pages/Animais/utilsAnimais';
 
 export function carregarRegistro(numero) {
-  return JSON.parse(localStorage.getItem(`registroReprodutivo_${numero}`) || '[]');
+  const raw = localStorage.getItem(`registroReprodutivo_${numero}`);
+  if (!raw) return { ocorrencias: [] };
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return { ocorrencias: parsed };
+    return parsed || { ocorrencias: [] };
+  } catch {
+    return { ocorrencias: [] };
+  }
 }
 
 export function salvarRegistro(numero, dados) {
@@ -10,9 +18,10 @@ export function salvarRegistro(numero, dados) {
 }
 
 export function adicionarOcorrencia(numero, ocorrencia) {
-  const dados = carregarRegistro(numero);
-  dados.push(ocorrencia);
-  salvarRegistro(numero, dados);
+  const registro = carregarRegistro(numero);
+  if (!Array.isArray(registro.ocorrencias)) registro.ocorrencias = [];
+  registro.ocorrencias.push(ocorrencia);
+  salvarRegistro(numero, registro);
   window.dispatchEvent(new Event('registroReprodutivoAtualizado'));
 }
 
@@ -36,9 +45,9 @@ export function listarAnimaisPorProtocolo(protocolId) {
   if (!protocolId) return [];
   const animais = JSON.parse(localStorage.getItem('animais') || '[]');
   return animais.reduce((acc, a) => {
-    const regs = carregarRegistro(a.numero);
-    const r = regs.find(t => t.protocoloId === protocolId && !t.concluido);
-    if (r) acc.push({ numero: a.numero, dataInicio: r.data });
+    const registro = carregarRegistro(a.numero);
+    const r = (registro.ocorrencias || []).find(t => t.protocoloId === protocolId && !t.concluido);
+    if (r) acc.push({ numero: a.numero, nome: a.brinco || a.nome || '', dataInicio: r.data, status: r.concluido ? 'Concluído' : 'Em andamento' });
     return acc;
   }, []);
 }


### PR DESCRIPTION
## Summary
- track reproductive events per animal in `registroReprodutivo_*`
- register IATF protocol info when recording occurrences
- show animals currently in a protocol
- load latest protocol action in reproduction dashboard
- display protocol occurrences in animal history

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b33f35ae08328bf886f056ae6b66c