### PR TITLE
Update reproduction protocol display

### DIFF
--- a/src/pages/Reproducao/VisaoGeralReproducao.jsx
+++ b/src/pages/Reproducao/VisaoGeralReproducao.jsx
@@ -6,7 +6,7 @@ import { getStatusVaca, filtrarAnimaisAtivos, filtrarPorStatus } from './utilsRe
 import ModalRegistrarOcorrencia from './ModalRegistrarOcorrencia';
 import '../../styles/tabelaModerna.css';
 import '../../styles/botoes.css';
-import { carregarRegistro } from '../../utils/registroReproducao';
+import { carregarRegistro, calcularEtapasOcorrencia } from '../../utils/registroReproducao';
 
 export default function VisaoGeralReproducao() {
   const [vacas, setVacas] = useState([]);
@@ -30,14 +30,19 @@ export default function VisaoGeralReproducao() {
     const ativos = filtrarAnimaisAtivos(animais).map(a => {
       const registro = carregarRegistro(a.numero);
       const ocorr = registro.ocorrencias || [];
+
       if (ocorr.length) {
         const ultimo = ocorr[ocorr.length - 1];
         a.ultimaAcao = { tipo: ultimo.tipo, data: ultimo.data };
-        if (ultimo.proximaEtapa) a.proximaAcao = {
-          tipo: ultimo.proximaEtapa.nome,
-          dataPrevista: ultimo.proximaEtapa.data
-        };
       }
+
+      const protocolo = [...ocorr].reverse().find(o => Array.isArray(o.etapas));
+      if (protocolo) {
+        const { ultima, proxima } = calcularEtapasOcorrencia(protocolo);
+        a.ultimaAcao = ultima;
+        a.proximaAcao = proxima;
+      }
+
       return a;
     });
     setVacas(ativos);

--- a/src/utils/registroReproducao.js
+++ b/src/utils/registroReproducao.js
@@ -41,6 +41,34 @@ export function calcularProximaEtapa(protocolo, inicio) {
   return null;
 }
 
+export function calcularEtapasOcorrencia(ocorrencia) {
+  if (!ocorrencia || !Array.isArray(ocorrencia.etapas)) {
+    return { ultima: null, proxima: null };
+  }
+
+  const [d, m, a] = ocorrencia.data.split('/');
+  const inicio = new Date(`${a}-${m}-${d}`);
+  const hoje = new Date();
+  const etapasOrdenadas = [...ocorrencia.etapas].sort((x, y) => x.dia - y.dia);
+
+  let ultima = { tipo: ocorrencia.tipo, data: ocorrencia.data };
+  let proxima = null;
+
+  for (const et of etapasOrdenadas) {
+    const dataEtapa = addDays(inicio, et.dia);
+    const nome = et.acao || et.hormonio || 'Etapa';
+    if (dataEtapa <= hoje) {
+      ultima = { tipo: nome, data: formatarDataBR(dataEtapa) };
+    } else if (!proxima) {
+      proxima = { tipo: nome, dataPrevista: formatarDataBR(dataEtapa) };
+    }
+  }
+
+  if (!proxima) proxima = { tipo: 'Protocolo concluído', dataPrevista: '—' };
+
+  return { ultima, proxima };
+}
+
 export function listarAnimaisPorProtocolo(protocolId) {
   if (!protocolId) return [];
   const animais = JSON.parse(localStorage.getItem('animais') || '[]');


### PR DESCRIPTION
## Summary
- compute last/next protocol step when displaying reproduction table
- add helper to evaluate protocol stages

## Testing
- `npm install` *(fails: max listeners exceeded due to no network)*

------
https://chatgpt.com/codex/tasks/task_e_684b3bb0e8408328b164ab05d852071e