### PR TITLE
Implement admin email check on login

### DIFF
--- a/backend/config/admins.js
+++ b/backend/config/admins.js
@@ -1,1 +1,1 @@
-module.exports = ["fernando@gestaoleiteira.com"];
+module.exports = ['fernando@gestaoleiteira.com'];

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -129,14 +129,17 @@ function login(req, res) {
     return res.status(400).json({ message: 'Senha incorreta' });
   }
 
+  const listaAdmins = require('../config/admins');
+  const isAdmin = listaAdmins.includes(email);
+
   const payload = {
     idProdutor: usuario.id,
     email: usuario.email,
-    perfil: usuario.perfil,
+    perfil: isAdmin ? 'admin' : usuario.perfil,
   };
 
   const token = jwt.sign(payload, SECRET, { expiresIn: '7d' });
-  res.json({ token, isAdmin: usuario.perfil === 'admin' });
+  res.json({ token, isAdmin });
 }
 
 // ➤ Dados do usuário logado


### PR DESCRIPTION
## Summary
- centralize admin emails in `backend/config/admins.js`
- use the list in `login()` to mark admins regardless of DB value

## Testing
- `npm install` *(fails: cannot reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_687237ae559c8328bbd6f66bd3022cf2