### PR TITLE
Add admin plan management panel

### DIFF
--- a/src/layout/NavegacaoPrincipal.jsx
+++ b/src/layout/NavegacaoPrincipal.jsx
@@ -38,6 +38,7 @@ export default function NavegacaoPrincipal() {
     { id: 'calendario', label: 'CALENDÁRIO', icone: '/icones/calendario.png', title: 'Agenda de atividades', visivelPara: ['admin', 'funcionario'] },
     { id: 'ajustes', label: 'AJUSTES', icone: '/icones/indicadores.png', title: 'Configurações do sistema', visivelPara: ['admin', 'funcionario'] },
     { id: 'admin', label: 'ADMIN', icone: '/icones/indicadores.png', title: 'Painel administrativo', visivelPara: ['admin'] },
+    { id: 'painel-admin-planos', label: 'PLANOS', icone: '/icones/indicadores.png', title: 'Gestão de planos', visivelPara: ['admin'] },
   ].filter((aba) => aba.visivelPara.includes(tipoUsuario));
 
   const containerRef = useRef();

--- a/src/pages/Admin/PainelPlanosAdmin.jsx
+++ b/src/pages/Admin/PainelPlanosAdmin.jsx
@@ -1,0 +1,133 @@
+import { useEffect, useState } from 'react';
+import api from '../../api';
+import { toast } from 'react-toastify';
+import '../../styles/botoes.css';
+
+export default function PainelPlanosAdmin() {
+  const [usuarios, setUsuarios] = useState([]);
+  const [novoPlano, setNovoPlano] = useState({});
+  const [carregando, setCarregando] = useState(false);
+
+  useEffect(() => {
+    carregar();
+  }, []);
+
+  const carregar = async () => {
+    setCarregando(true);
+    try {
+      const res = await api.get('/admin/planos');
+      setUsuarios(res.data);
+    } catch (e) {
+      toast.error('Erro ao carregar usuários');
+    } finally {
+      setCarregando(false);
+    }
+  };
+
+  const aprovar = async (id) => {
+    try {
+      await api.patch(`/admin/aprovar-pagamento/${id}`);
+      toast.success('Pagamento aprovado');
+      carregar();
+    } catch (e) {
+      toast.error(e.response?.data?.error || 'Erro ao aprovar');
+    }
+  };
+
+  const alterarPlano = async (id) => {
+    const plano = novoPlano[id];
+    if (!plano) return;
+    try {
+      await api.patch(`/admin/definir-plano/${id}`, { plano });
+      toast.success('Plano alterado');
+      carregar();
+    } catch (e) {
+      toast.error(e.response?.data?.error || 'Erro ao alterar');
+    }
+  };
+
+  const toggleBloqueio = async (id) => {
+    try {
+      await api.patch(`/admin/bloquear/${id}`);
+      toast.success('Status atualizado');
+      carregar();
+    } catch (e) {
+      toast.error(e.response?.data?.error || 'Erro ao atualizar status');
+    }
+  };
+
+  const concederExtra = async (id) => {
+    const dias = prompt('Dias de acesso extra?');
+    if (!dias) return;
+    try {
+      await api.patch(`/admin/liberar/${id}`, { dias });
+      toast.success('Período atualizado');
+      carregar();
+    } catch (e) {
+      toast.error(e.response?.data?.error || 'Erro ao conceder');
+    }
+  };
+
+  const formatarData = (d) => (d ? new Date(d).toLocaleDateString() : '-');
+
+  return (
+    <div className="p-4 space-y-4">
+      <h1 className="text-xl font-bold">Gestão de Planos</h1>
+      <table className="min-w-full bg-white rounded shadow text-sm">
+        <thead>
+          <tr className="border-b bg-gray-100">
+            <th className="p-2 text-left">Nome</th>
+            <th className="p-2 text-left">E-mail</th>
+            <th className="p-2 text-center">Plano Atual</th>
+            <th className="p-2 text-center">Solicitado</th>
+            <th className="p-2 text-center">Pagamento</th>
+            <th className="p-2 text-center">Status</th>
+            <th className="p-2 text-center">Datas</th>
+            <th className="p-2 text-center">Ações</th>
+          </tr>
+        </thead>
+        <tbody>
+          {usuarios.map((u) => (
+            <tr key={u.id} className="border-b">
+              <td className="p-2">{u.nome}</td>
+              <td className="p-2">{u.email}</td>
+              <td className="p-2 text-center">{u.plano || '-'}</td>
+              <td className="p-2 text-center">{u.planoSolicitado || '-'}</td>
+              <td className="p-2 text-center">{u.formaPagamento || '-'}</td>
+              <td className="p-2 text-center">{u.status}</td>
+              <td className="p-2 text-center">
+                {formatarData(u.dataLiberado)} - {formatarData(u.dataFimLiberacao)}
+              </td>
+              <td className="p-2 text-center space-x-1">
+                <button className="botao-editar" onClick={() => aprovar(u.id)}>
+                  Aprovar
+                </button>
+                <select
+                  className="border rounded px-1 py-0.5"
+                  value={novoPlano[u.id] ?? ''}
+                  onChange={(e) => setNovoPlano({ ...novoPlano, [u.id]: e.target.value })}
+                >
+                  <option value="">Plano...</option>
+                  <option value="gratis">Grátis</option>
+                  <option value="basico">Básico</option>
+                  <option value="intermediario">Intermediário</option>
+                  <option value="completo">Completo</option>
+                </select>
+                <button className="botao-editar" onClick={() => alterarPlano(u.id)}>
+                  Mudar
+                </button>
+                <button className="botao-editar" onClick={() => toggleBloqueio(u.id)}>
+                  {u.status === 'bloqueado' ? 'Desbloquear' : 'Bloquear'}
+                </button>
+                <button className="botao-editar" onClick={() => concederExtra(u.id)}>
+                  Extra
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {carregando && <div className="text-center">Carregando...</div>}
+    </div>
+  );
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -21,6 +21,7 @@ import EsqueciSenha from './pages/Auth/EsqueciSenha';
 import BemVindo from './pages/Auth/BemVindo';
 import Admin from './pages/Admin/Admin';
 import ListaUsuarios from './pages/Admin/ListaUsuarios';
+import PainelPlanosAdmin from './pages/Admin/PainelPlanosAdmin';
 import RotaAdmin from './utils/RotaAdmin';
 import Fazenda from './pages/Fazenda/Fazenda';
 import Logout from './pages/Auth/Logout';
@@ -52,6 +53,7 @@ const routes = createRoutesFromElements(
   <Route path="/bemvindo" element={<BemVindo />} />
   <Route path="/admin" element={<RotaAdmin><Admin /></RotaAdmin>} />
   <Route path="/admin/usuarios" element={<RotaAdmin><ListaUsuarios /></RotaAdmin>} />
+  <Route path="/painel-admin-planos" element={<RotaAdmin><PainelPlanosAdmin /></RotaAdmin>} />
   <Route path="/fazenda" element={<Fazenda />} />
   <Route path="/painel" element={<Fazenda />} />
   <Route path="/configuracoes-inicial" element={<ConfigTelaInicial />} />


### PR DESCRIPTION
## Summary
- implement `/admin/planos` API to list plans
- allow toggling block status and approving payments with dates
- add endpoint to set plan directly
- add React admin page `PainelPlanosAdmin`
- register new route and menu entry

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687456ff7670832893166f83587be2a0