### PR TITLE
Implement user plan selection page

### DIFF
--- a/src/layout/NavegacaoPrincipal.jsx
+++ b/src/layout/NavegacaoPrincipal.jsx
@@ -37,6 +37,7 @@ export default function NavegacaoPrincipal() {
     { id: 'financeiro', label: 'FINANCEIRO', icone: '/icones/financeiro.png', title: 'Relatórios financeiros', visivelPara: ['admin', 'funcionario'] },
     { id: 'calendario', label: 'CALENDÁRIO', icone: '/icones/calendario.png', title: 'Agenda de atividades', visivelPara: ['admin', 'funcionario'] },
     { id: 'ajustes', label: 'AJUSTES', icone: '/icones/indicadores.png', title: 'Configurações do sistema', visivelPara: ['admin', 'funcionario'] },
+    { id: 'planos', label: 'PLANOS', icone: '/icones/indicadores.png', title: 'Escolher plano', visivelPara: ['admin', 'funcionario'] },
     { id: 'admin', label: 'ADMIN', icone: '/icones/indicadores.png', title: 'Painel administrativo', visivelPara: ['admin'] },
     { id: 'painel-admin-planos', label: 'PLANOS', icone: '/icones/indicadores.png', title: 'Gestão de planos', visivelPara: ['admin'] },
     { id: 'relatorio-admin', label: 'RELATÓRIOS', icone: '/icones/relatorios.png', title: 'Relatórios administrativos', visivelPara: ['admin'] },

--- a/src/pages/EscolherPlanoUsuario.jsx
+++ b/src/pages/EscolherPlanoUsuario.jsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+import { toast } from 'react-toastify';
+import api from '../api';
+import '../styles/botoes.css';
+
+export default function EscolherPlanoUsuario() {
+  const [plano, setPlano] = useState('');
+  const [formaPagamento, setFormaPagamento] = useState('pix');
+  const [enviando, setEnviando] = useState(false);
+
+  const solicitar = async () => {
+    if (!plano) return;
+    setEnviando(true);
+    try {
+      await api.post('/usuario/solicitar-plano', {
+        plano,
+        formaPagamento,
+      });
+      toast.success('Plano solicitado com sucesso. Aguarde aprovação.');
+      setPlano('');
+      setFormaPagamento('pix');
+    } catch (err) {
+      toast.error(
+        err.response?.data?.error || err.message || 'Erro ao solicitar plano'
+      );
+    } finally {
+      setEnviando(false);
+    }
+  };
+
+  return (
+    <div className="p-4 max-w-md mx-auto space-y-4">
+      <h1 className="text-xl font-bold text-center">Escolher Plano</h1>
+      <p className="text-center text-sm">
+        Escolha o plano desejado e informe a forma de pagamento.
+      </p>
+
+      <div className="flex flex-col gap-2">
+        <label className="font-medium">Plano</label>
+        <select
+          value={plano}
+          onChange={(e) => setPlano(e.target.value)}
+          className="border rounded p-2"
+        >
+          <option value="">Selecione...</option>
+          <option value="basico">Básico</option>
+          <option value="intermediario">Intermediário</option>
+          <option value="completo">Completo</option>
+        </select>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <label className="font-medium">Forma de pagamento</label>
+        <select
+          value={formaPagamento}
+          onChange={(e) => setFormaPagamento(e.target.value)}
+          className="border rounded p-2"
+        >
+          <option value="pix">Pix</option>
+          <option value="cartao">Cartão</option>
+          <option value="dinheiro">Dinheiro</option>
+        </select>
+      </div>
+
+      <button
+        className="botao-acao w-full"
+        onClick={solicitar}
+        disabled={!plano || enviando}
+      >
+        {enviando ? 'Enviando...' : 'Solicitar Plano'}
+      </button>
+    </div>
+  );
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -28,6 +28,7 @@ import Fazenda from './pages/Fazenda/Fazenda';
 import Logout from './pages/Auth/Logout';
 import ConfigTelaInicial from './pages/ConfigTelaInicial';
 import EscolherPlano from './pages/EscolherPlano';
+import EscolherPlanoUsuario from './pages/EscolherPlanoUsuario';
 
 const routes = createRoutesFromElements(
   <>
@@ -60,6 +61,7 @@ const routes = createRoutesFromElements(
   <Route path="/painel" element={<Fazenda />} />
   <Route path="/configuracoes-inicial" element={<ConfigTelaInicial />} />
   <Route path="/escolher-plano" element={<RotaProtegida><EscolherPlano /></RotaProtegida>} />
+  <Route path="/planos" element={<RotaProtegida><EscolherPlanoUsuario /></RotaProtegida>} />
   <Route path="logout" element={<Logout />} />
   </>
 );


### PR DESCRIPTION
## Summary
- add new page `EscolherPlanoUsuario` for requesting a plan
- register route `/planos`
- show new menu option "PLANOS" for users

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6874e50d771c832888a4f09071937d6d