### PR TITLE
Add user plan request route

### DIFF
--- a/backend/routes/rotasExtras.js
+++ b/backend/routes/rotasExtras.js
@@ -13,6 +13,7 @@ router.use('/eventos', require('./eventosRoutes'));
 router.use('/produtos', require('./produtosRoutes'));
 router.use('/examesSanitarios', require('./examesSanitariosRoutes'));
 router.use('/racas', require('./racasRoutes'));
+router.use('/usuario', require('./usuarioRoutes'));
 router.use('/', require('./mockRoutes'));
 router.use('/', require('./adminRoutes'));
 

--- a/backend/routes/usuarioRoutes.js
+++ b/backend/routes/usuarioRoutes.js
@@ -1,0 +1,34 @@
+const express = require('express');
+const router = express.Router();
+const { initDB } = require('../db');
+const autenticarToken = require('../middleware/autenticarToken');
+
+router.use(autenticarToken);
+
+router.post('/solicitar-plano', (req, res) => {
+  const { plano, formaPagamento } = req.body;
+
+  if (!plano || !formaPagamento) {
+    return res.status(400).json({ error: 'Dados incompletos' });
+  }
+
+  const planosValidos = ['basico', 'intermediario', 'completo'];
+  const formasValidas = ['pix', 'cartao', 'dinheiro'];
+
+  if (!planosValidos.includes(plano) || !formasValidas.includes(formaPagamento)) {
+    return res.status(400).json({ error: 'Dados inválidos' });
+  }
+
+  const db = initDB(req.user.email);
+  const usuario = db.prepare('SELECT id FROM usuarios WHERE id = ?').get(req.user.idProdutor);
+  if (!usuario) {
+    return res.status(404).json({ error: 'Usuário não encontrado' });
+  }
+
+  db.prepare('UPDATE usuarios SET planoSolicitado = ?, formaPagamento = ?, status = ? WHERE id = ?')
+    .run(plano, formaPagamento, 'pendente', req.user.idProdutor);
+
+  res.json({ message: 'Plano solicitado com sucesso' });
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- add new POST route `/usuario/solicitar-plano`
- wire user route through rotasExtras

## Testing
- `npm install` *(fails: registry blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68751e5698c48328809333d7a969e228