### PR TITLE
Add plan cards with payment options

### DIFF
--- a/src/pages/EscolherPlanoUsuario.jsx
+++ b/src/pages/EscolherPlanoUsuario.jsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { toast } from 'react-toastify';
+import { Star, Rocket, Crown } from 'lucide-react';
 import api from '../api';
 import '../styles/botoes.css';
 
@@ -29,37 +30,71 @@ export default function EscolherPlanoUsuario() {
   };
 
   return (
-    <div className="p-4 max-w-md mx-auto space-y-4">
+    <div className="p-4 max-w-3xl mx-auto space-y-6">
       <h1 className="text-xl font-bold text-center">Escolher Plano</h1>
       <p className="text-center text-sm">
         Escolha o plano desejado e informe a forma de pagamento.
       </p>
 
-      <div className="flex flex-col gap-2">
-        <label className="font-medium">Plano</label>
-        <select
-          value={plano}
-          onChange={(e) => setPlano(e.target.value)}
-          className="border rounded p-2"
-        >
-          <option value="">Selecione...</option>
-          <option value="basico">Básico</option>
-          <option value="intermediario">Intermediário</option>
-          <option value="completo">Completo</option>
-        </select>
+      <div className="grid md:grid-cols-3 gap-4">
+        {[
+          {
+            id: 'basico',
+            nome: 'Básico',
+            descricao: 'Funcionalidades essenciais',
+            Icon: Star,
+          },
+          {
+            id: 'intermediario',
+            nome: 'Intermediário',
+            descricao:
+              'Inclui controle de bezerras, reprodução e estoque',
+            Icon: Rocket,
+          },
+          {
+            id: 'completo',
+            nome: 'Completo',
+            descricao:
+              'Tudo do intermediário + relatórios e gráficos avançados',
+            Icon: Crown,
+          },
+        ].map((p) => (
+          <div
+            key={p.id}
+            className={`border rounded-lg shadow-sm p-4 flex flex-col items-center text-center space-y-2 ${
+              plano === p.id ? 'ring-2 ring-blue-500' : 'border-gray-300'
+            }`}
+          >
+            <p.Icon size={36} className="text-blue-600" />
+            <h2 className="text-lg font-semibold">{p.nome}</h2>
+            <p className="text-sm flex-1">{p.descricao}</p>
+            <button
+              type="button"
+              onClick={() => setPlano(p.id)}
+              className="botao-acao"
+            >
+              {plano === p.id ? 'Selecionado' : 'Selecionar'}
+            </button>
+          </div>
+        ))}
       </div>
 
-      <div className="flex flex-col gap-2">
+      <div className="space-y-2">
         <label className="font-medium">Forma de pagamento</label>
-        <select
-          value={formaPagamento}
-          onChange={(e) => setFormaPagamento(e.target.value)}
-          className="border rounded p-2"
-        >
-          <option value="pix">Pix</option>
-          <option value="cartao">Cartão</option>
-          <option value="dinheiro">Dinheiro</option>
-        </select>
+        <div className="flex gap-4">
+          {['pix', 'cartao', 'dinheiro'].map((fp) => (
+            <label key={fp} className="flex items-center gap-1">
+              <input
+                type="radio"
+                name="formaPagamento"
+                value={fp}
+                checked={formaPagamento === fp}
+                onChange={(e) => setFormaPagamento(e.target.value)}
+              />
+              {fp.charAt(0).toUpperCase() + fp.slice(1)}
+            </label>
+          ))}
+        </div>
       </div>
 
       <button


### PR DESCRIPTION
## Summary
- improve the EscolherPlanoUsuario screen with plan cards and icons
- allow choosing Pix, Cartão or Dinheiro via radio buttons
- keep existing menu item and route

## Testing
- `npm test` *(fails: Missing script)*
- `npx vite build` *(fails: 403 Forbidden due to missing internet access)*

------
https://chatgpt.com/codex/tasks/task_e_687520a6e05c8328946a7e2c7747ba26