### PR TITLE
Update admin and plan interfaces

### DIFF
--- a/src/components/ModalPlanoSelecionado.jsx
+++ b/src/components/ModalPlanoSelecionado.jsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import '../styles/botoes.css';
+
+export default function ModalPlanoSelecionado({ plano, onConfirmar, onFechar }) {
+  const [forma, setForma] = useState('pix');
+
+  if (!plano) return null;
+
+  return (
+    <div style={overlay} onClick={onFechar}>
+      <div style={modal} onClick={(e) => e.stopPropagation()}>
+        <h3 className="text-lg font-semibold mb-2 text-center">
+          Confirmar plano {plano.nome}
+        </h3>
+        <select
+          className="border rounded w-full p-2 mb-4"
+          value={forma}
+          onChange={(e) => setForma(e.target.value)}
+        >
+          <option value="pix">Pix</option>
+          <option value="boleto">Boleto</option>
+          <option value="cartao">Cartão</option>
+        </select>
+        <div className="flex justify-end gap-2">
+          <button className="botao-cancelar pequeno" onClick={onFechar}>
+            Cancelar
+          </button>
+          <button
+            className="botao-acao pequeno"
+            onClick={() => onConfirmar(forma)}
+          >
+            Confirmar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const overlay = {
+  position: 'fixed',
+  inset: 0,
+  backgroundColor: 'rgba(0,0,0,0.5)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 1000,
+};
+
+const modal = {
+  background: '#fff',
+  borderRadius: '0.75rem',
+  width: 'min(90vw, 360px)',
+  padding: '1rem',
+};

--- a/src/pages/Admin/AdminPainel.jsx
+++ b/src/pages/Admin/AdminPainel.jsx
@@ -1,20 +1,24 @@
 import { useEffect, useState } from 'react';
 import api from '../../api';
 import { toast } from 'react-toastify';
+import '../../styles/botoes.css';
 
 export default function AdminPainel() {
   const [usuarios, setUsuarios] = useState([]);
-  const [perfis, setPerfis] = useState({});
   const [carregando, setCarregando] = useState(false);
+  const [modalLiberar, setModalLiberar] = useState(null);
+  const [modalBloquear, setModalBloquear] = useState(null);
+  const [modalAlterar, setModalAlterar] = useState(null);
+  const [modalExcluir, setModalExcluir] = useState(null);
 
   useEffect(() => {
-    carregarUsuarios();
+    carregar();
   }, []);
 
-  const carregarUsuarios = async () => {
+  const carregar = async () => {
     setCarregando(true);
     try {
-      const res = await api.get('/admin/usuarios');
+      const res = await api.get('/admin/planos');
       setUsuarios(res.data);
     } catch (err) {
       toast.error('Erro ao carregar usuários');
@@ -23,88 +27,246 @@ export default function AdminPainel() {
     }
   };
 
-  const alterarStatus = async (id) => {
+  const liberar = async () => {
     try {
-      await api.patch(`/admin/status/${id}`);
-      toast.success('Status atualizado');
-      carregarUsuarios();
+      await api.patch(`/admin/liberar/${modalLiberar.id}`, { dias: modalLiberar.dias });
+      toast.success('Usuário liberado');
+      setModalLiberar(null);
+      carregar();
     } catch (err) {
-      toast.error(err.response?.data?.error || 'Erro ao alterar status');
+      toast.error(err.response?.data?.error || 'Erro ao liberar');
     }
   };
 
-  const alterarPerfil = async (email, perfil) => {
+  const bloquear = async () => {
     try {
-      await api.patch(`/admin/usuarios/${email}`, { perfil });
-      toast.success('Perfil atualizado');
-      carregarUsuarios();
+      await api.patch(`/admin/bloquear/${modalBloquear}`);
+      toast.success('Usuário atualizado');
+      setModalBloquear(null);
+      carregar();
     } catch (err) {
-      toast.error(err.response?.data?.error || 'Erro ao alterar perfil');
+      toast.error(err.response?.data?.error || 'Erro ao bloquear');
     }
   };
 
-  const excluirUsuario = async (id) => {
+  const alterarPlano = async () => {
     try {
-      await api.delete(`/admin/usuarios/${id}`);
+      await api.patch(`/admin/alterar-plano/${modalAlterar.id}`, {
+        planoSolicitado: modalAlterar.plano,
+        formaPagamento: modalAlterar.forma,
+      });
+      toast.success('Plano alterado');
+      setModalAlterar(null);
+      carregar();
+    } catch (err) {
+      toast.error(err.response?.data?.error || 'Erro ao alterar plano');
+    }
+  };
+
+  const aprovarPlano = async (id) => {
+    try {
+      await api.patch(`/admin/aprovar-pagamento/${id}`);
+      toast.success('Plano aprovado');
+      carregar();
+    } catch (err) {
+      toast.error(err.response?.data?.error || 'Erro ao aprovar');
+    }
+  };
+
+  const excluirUsuario = async () => {
+    try {
+      await api.delete(`/admin/usuarios/${modalExcluir.id}`, {
+        data: { motivo: modalExcluir.motivo, backup: modalExcluir.backup },
+      });
       toast.success('Usuário excluído');
-      carregarUsuarios();
+      setModalExcluir(null);
+      carregar();
     } catch (err) {
       toast.error(err.response?.data?.error || 'Erro ao excluir');
     }
   };
 
+  const badge = (status) => {
+    const cores = {
+      ativo: 'bg-green-100 text-green-700',
+      bloqueado: 'bg-red-100 text-red-700',
+      pendente: 'bg-yellow-100 text-yellow-700',
+      teste: 'bg-blue-100 text-blue-700',
+      inativo: 'bg-gray-100 text-gray-700',
+    };
+    return (
+      <span className={`px-2 py-0.5 rounded text-xs font-medium ${cores[status] || 'bg-gray-100 text-gray-700'}`}>{status}</span>
+    );
+  };
+
   return (
     <div className="p-4 space-y-4">
       <h1 className="text-xl font-bold">Painel Administrativo</h1>
-      <table className="min-w-full bg-white rounded shadow text-sm">
-        <thead>
-          <tr className="border-b bg-gray-100">
-            <th className="p-2 text-left">Nome</th>
-            <th className="p-2 text-left">Email</th>
-            <th className="p-2 text-center">Status</th>
-            <th className="p-2 text-center">Plano Atual</th>
-            <th className="p-2 text-center">Ações</th>
-          </tr>
-        </thead>
-        <tbody>
-          {usuarios.map((u) => (
-            <tr key={u.email} className="border-b">
-              <td className="p-2">{u.nome}</td>
-              <td className="p-2">{u.email}</td>
-              <td className="p-2 text-center">{u.verificado ? 'ativo' : 'suspenso'}</td>
-              <td className="p-2 text-center">
-                <select
-                  className="border rounded px-1 py-0.5"
-                  value={perfis[u.email] ?? u.perfil}
-                  onChange={(e) => {
-                    const valor = e.target.value;
-                    setPerfis({ ...perfis, [u.email]: valor });
-                    alterarPerfil(u.email, valor);
-                  }}
-                >
-                  <option value="usuario">Usuário</option>
-                  <option value="admin">Admin</option>
-                </select>
-              </td>
-              <td className="p-2 text-center space-x-1">
-                <button
-                  className="bg-yellow-600 text-white px-2 py-1 rounded"
-                  onClick={() => alterarStatus(u.id)}
-                >
-                  {u.verificado ? 'Suspender' : 'Reativar'}
-                </button>
-                <button
-                  className="bg-red-600 text-white px-2 py-1 rounded"
-                  onClick={() => excluirUsuario(u.id)}
-                >
-                  Excluir
-                </button>
-              </td>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-100">
+            <tr>
+              <th className="px-2 py-2 text-left">Nome</th>
+              <th className="px-2 py-2 text-left">Email</th>
+              <th className="px-2 py-2 text-left">Telefone</th>
+              <th className="px-2 py-2 text-center">Plano Atual</th>
+              <th className="px-2 py-2 text-center">Plano Solicitado</th>
+              <th className="px-2 py-2 text-center">Status</th>
+              <th className="px-2 py-2 text-center">Ações</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {usuarios.map((u) => (
+              <tr key={u.id} className="border-b">
+                <td className="px-2 py-1">{u.nome}</td>
+                <td className="px-2 py-1">{u.email}</td>
+                <td className="px-2 py-1">{u.telefone || '-'}</td>
+                <td className="px-2 py-1 text-center">{u.plano || '-'}</td>
+                <td className="px-2 py-1 text-center">
+                  {u.planoSolicitado ? (
+                    <span className="flex items-center justify-center gap-1">
+                      {u.planoSolicitado} <span>🕒</span>
+                    </span>
+                  ) : (
+                    '-'
+                  )}
+                </td>
+                <td className="px-2 py-1 text-center">{badge(u.status)}</td>
+                <td className="px-2 py-1 text-center flex flex-wrap gap-2 justify-center">
+                  <button className="botao-editar" onClick={() => setModalLiberar({ id: u.id, dias: 30 })}>🔓 Liberar</button>
+                  <button className="botao-editar" onClick={() => setModalBloquear(u.id)}>🚫 Bloquear</button>
+                  <button className="botao-editar" onClick={() => setModalAlterar({ id: u.id, plano: '', forma: 'pix' })}>📦 Alterar Plano</button>
+                  {u.planoSolicitado && (
+                    <button className="botao-editar" onClick={() => aprovarPlano(u.id)}>
+                      ✅ Aprovar Plano
+                    </button>
+                  )}
+                  <button className="botao-editar" onClick={() => setModalExcluir({ id: u.id, motivo: '', backup: false, texto: '' })}>🗑️ Excluir</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
       {carregando && <div className="text-center">Carregando...</div>}
+
+      {modalLiberar && (
+        <div style={overlay} onClick={() => setModalLiberar(null)}>
+          <div style={modal} onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-lg font-semibold mb-2 text-center">Liberar acesso</h3>
+            <input
+              type="number"
+              className="border rounded w-full p-2 mb-4"
+              value={modalLiberar.dias}
+              onChange={(e) => setModalLiberar((m) => ({ ...m, dias: e.target.value }))}
+            />
+            <div className="flex justify-end gap-2">
+              <button className="botao-cancelar pequeno" onClick={() => setModalLiberar(null)}>Cancelar</button>
+              <button className="botao-acao pequeno" onClick={liberar}>Confirmar</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {modalBloquear && (
+        <div style={overlay} onClick={() => setModalBloquear(null)}>
+          <div style={modal} onClick={(e) => e.stopPropagation()}>
+            <p className="mb-4">Deseja bloquear este usuário?</p>
+            <div className="flex justify-end gap-2">
+              <button className="botao-cancelar pequeno" onClick={() => setModalBloquear(null)}>Cancelar</button>
+              <button className="botao-acao pequeno" onClick={bloquear}>Confirmar</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {modalAlterar && (
+        <div style={overlay} onClick={() => setModalAlterar(null)}>
+          <div style={modal} onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-lg font-semibold mb-2 text-center">Alterar Plano</h3>
+            <select
+              className="border rounded w-full p-2 mb-2"
+              value={modalAlterar.plano}
+              onChange={(e) => setModalAlterar((m) => ({ ...m, plano: e.target.value }))}
+            >
+              <option value="">Selecione</option>
+              <option value="basico">Básico</option>
+              <option value="intermediario">Intermediário</option>
+              <option value="completo">Completo</option>
+            </select>
+            <select
+              className="border rounded w-full p-2 mb-4"
+              value={modalAlterar.forma}
+              onChange={(e) => setModalAlterar((m) => ({ ...m, forma: e.target.value }))}
+            >
+              <option value="pix">Pix</option>
+              <option value="boleto">Boleto</option>
+              <option value="cartao">Cartão</option>
+            </select>
+            <div className="flex justify-end gap-2">
+              <button className="botao-cancelar pequeno" onClick={() => setModalAlterar(null)}>Cancelar</button>
+              <button className="botao-acao pequeno" onClick={alterarPlano}>Confirmar</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {modalExcluir && (
+        <div style={overlay} onClick={() => setModalExcluir(null)}>
+          <div style={modal} onClick={(e) => e.stopPropagation()}>
+            <h3 className="text-lg font-semibold mb-2 text-center">Excluir usuário</h3>
+            <input
+              type="text"
+              placeholder="Motivo"
+              className="border rounded w-full p-2 mb-2"
+              value={modalExcluir.motivo}
+              onChange={(e) => setModalExcluir((m) => ({ ...m, motivo: e.target.value }))}
+            />
+            <label className="flex items-center gap-2 mb-2">
+              <input
+                type="checkbox"
+                checked={modalExcluir.backup}
+                onChange={(e) => setModalExcluir((m) => ({ ...m, backup: e.target.checked }))}
+              />
+              Fazer backup dos dados antes de excluir
+            </label>
+            <input
+              type="text"
+              placeholder="Digite EXCLUIR para confirmar"
+              className="border rounded w-full p-2 mb-4"
+              value={modalExcluir.texto}
+              onChange={(e) => setModalExcluir((m) => ({ ...m, texto: e.target.value }))}
+            />
+            <div className="flex justify-end gap-2">
+              <button className="botao-cancelar pequeno" onClick={() => setModalExcluir(null)}>Cancelar</button>
+              <button
+                className="botao-acao pequeno"
+                disabled={modalExcluir.texto !== 'EXCLUIR'}
+                onClick={excluirUsuario}
+              >
+                Confirmar
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
+
+const overlay = {
+  position: 'fixed',
+  inset: 0,
+  backgroundColor: 'rgba(0,0,0,0.5)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 1000,
+};
+
+const modal = {
+  background: '#fff',
+  borderRadius: '0.75rem',
+  width: 'min(90vw, 380px)',
+  padding: '1rem',
+};

--- a/src/pages/EscolherPlanoUsuario.jsx
+++ b/src/pages/EscolherPlanoUsuario.jsx
@@ -2,23 +2,43 @@ import { useState } from 'react';
 import { toast } from 'react-toastify';
 import { Star, Rocket, Crown } from 'lucide-react';
 import api from '../api';
+import ModalPlanoSelecionado from '../components/ModalPlanoSelecionado';
 
 export default function EscolherPlanoUsuario() {
-  const [plano, setPlano] = useState('');
-  const [formaPagamento, setFormaPagamento] = useState('pix');
+  const planos = [
+    {
+      id: 'basico',
+      nome: 'Básico',
+      descricao: 'Funcionalidades essenciais',
+      Icon: Star,
+    },
+    {
+      id: 'intermediario',
+      nome: 'Intermediário',
+      descricao: 'Inclui controle de bezerras, reprodução e estoque',
+      Icon: Rocket,
+    },
+    {
+      id: 'completo',
+      nome: 'Completo',
+      descricao: 'Tudo do intermediário + relatórios e gráficos avançados',
+      Icon: Crown,
+    },
+  ];
+
+  const [planoSelecionado, setPlanoSelecionado] = useState(null);
   const [enviando, setEnviando] = useState(false);
 
-  const solicitar = async () => {
-    if (!plano) return;
+  const solicitar = async (formaPagamento) => {
+    if (!planoSelecionado) return;
     setEnviando(true);
     try {
-      await api.post('/usuario/solicitar-plano', {
-        plano,
+      await api.patch('/usuario/solicitar-plano', {
+        planoSolicitado: planoSelecionado.id,
         formaPagamento,
       });
-      toast.success('Plano solicitado com sucesso. Aguarde aprovação.');
-      setPlano('');
-      setFormaPagamento('pix');
+      toast.success('Seu pedido foi enviado. Aguarde a aprovação.');
+      setPlanoSelecionado(null);
     } catch (err) {
       toast.error(
         err.response?.data?.error || err.message || 'Erro ao solicitar plano'
@@ -36,76 +56,28 @@ export default function EscolherPlanoUsuario() {
       </p>
 
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        {[
-          {
-            id: 'basico',
-            nome: 'Básico',
-            descricao: 'Funcionalidades essenciais',
-            Icon: Star,
-          },
-          {
-            id: 'intermediario',
-            nome: 'Intermediário',
-            descricao:
-              'Inclui controle de bezerras, reprodução e estoque',
-            Icon: Rocket,
-          },
-          {
-            id: 'completo',
-            nome: 'Completo',
-            descricao:
-              'Tudo do intermediário + relatórios e gráficos avançados',
-            Icon: Crown,
-          },
-        ].map((p) => (
+        {planos.map((p) => (
           <div
             key={p.id}
-            onClick={() => setPlano(p.id)}
-            className={`cursor-pointer border rounded-lg shadow-sm p-4 flex flex-col items-center text-center space-y-2 transition ${
-              plano === p.id
-                ? 'border-blue-600 ring-2 ring-blue-500'
-                : 'border-gray-300 hover:shadow-md'
-            }`}
+            className="border rounded-lg shadow-sm p-4 flex flex-col items-center text-center space-y-2 hover:shadow-md transition cursor-pointer"
+            onClick={() => setPlanoSelecionado(p)}
           >
             <p.Icon size={36} className="text-blue-600" />
             <h2 className="text-lg font-semibold">{p.nome}</h2>
             <p className="text-sm flex-1">{p.descricao}</p>
-            <span
-              className={`text-sm font-medium ${
-                plano === p.id ? 'text-blue-600' : 'text-gray-600'
-              }`}
-            >
-              {plano === p.id ? 'Selecionado' : 'Selecionar'}
-            </span>
+            <span className="text-sm font-medium text-blue-600">Selecionar</span>
           </div>
         ))}
       </div>
 
-      <div className="space-y-2">
-        <label className="font-medium">Forma de pagamento</label>
-        <div className="flex gap-4">
-          {['pix', 'cartao', 'dinheiro'].map((fp) => (
-            <label key={fp} className="flex items-center gap-1">
-              <input
-                type="radio"
-                name="formaPagamento"
-                value={fp}
-                checked={formaPagamento === fp}
-                onChange={(e) => setFormaPagamento(e.target.value)}
-              />
-              {fp.charAt(0).toUpperCase() + fp.slice(1)}
-            </label>
-          ))}
-        </div>
-      </div>
 
-      <button
-        className="w-full bg-blue-600 hover:bg-blue-700 text-white font-semibold py-2 rounded transition disabled:bg-gray-400 disabled:cursor-not-allowed"
-        onClick={solicitar}
-        disabled={!plano || enviando}
-      >
-        {enviando ? 'Enviando...' : 'Solicitar Plano'}
-      </button>
+      {planoSelecionado && (
+        <ModalPlanoSelecionado
+          plano={planoSelecionado}
+          onFechar={() => setPlanoSelecionado(null)}
+          onConfirmar={solicitar}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- modernize admin table with action modals for plan and status management
- create reusable modal for selecting a plan
- refactor plan selection page to use modal and send PATCH request

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875a6fc5b0c8328a39b8433b1c98057