### PR TITLE
Add Exams tab in animal health modal

### DIFF
--- a/src/pages/Saude/ModalExame.jsx
+++ b/src/pages/Saude/ModalExame.jsx
@@ -1,0 +1,136 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { formatarDataDigitada } from '../Animais/utilsAnimais';
+
+export default function ModalExame({ onFechar, onSalvar, dados }) {
+  const [tipo, setTipo] = useState(dados?.tipo || '');
+  const [data, setData] = useState(dados?.data || '');
+  const [resultado, setResultado] = useState(dados?.resultado || '');
+  const [anexos, setAnexos] = useState(dados?.anexos || []);
+  const [responsavel, setResponsavel] = useState(dados?.responsavel || '');
+  const [observacoes, setObservacoes] = useState(dados?.observacoes || '');
+
+  const camposRef = useRef([]);
+
+  useEffect(() => {
+    const esc = (e) => e.key === 'Escape' && onFechar();
+    window.addEventListener('keydown', esc);
+    return () => window.removeEventListener('keydown', esc);
+  }, [onFechar]);
+
+  const handleEnter = (i) => (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      camposRef.current[i + 1]?.focus();
+    }
+  };
+
+  const handleFile = (files) => {
+    const arr = [];
+    Array.from(files || []).forEach((f) => {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        arr.push({ nome: f.name, dado: reader.result });
+        if (arr.length === files.length) setAnexos(arr);
+      };
+      reader.readAsDataURL(f);
+    });
+  };
+
+  const salvar = () => {
+    if (!tipo || !data) return;
+    onSalvar?.({ tipo, data, resultado, anexos, responsavel, observacoes });
+    onFechar?.();
+  };
+
+  return (
+    <div style={overlay} onClick={onFechar}>
+      <div style={modal} onClick={(e) => e.stopPropagation()}>
+        <div style={header}>Registrar Exame</div>
+        <div style={conteudo}>
+          <div>
+            <label>Tipo</label>
+            <input
+              ref={(el) => (camposRef.current[0] = el)}
+              value={tipo}
+              onChange={(e) => setTipo(e.target.value)}
+              onKeyDown={handleEnter(0)}
+              style={input}
+              list="tiposExame"
+            />
+            <datalist id="tiposExame">
+              <option value="Sangue" />
+              <option value="Fezes" />
+              <option value="Leite" />
+              <option value="Urina" />
+              <option value="Imagem" />
+              <option value="Outro" />
+            </datalist>
+          </div>
+          <div>
+            <label>Data</label>
+            <input
+              ref={(el) => (camposRef.current[1] = el)}
+              value={data}
+              onChange={(e) => setData(formatarDataDigitada(e.target.value))}
+              onKeyDown={handleEnter(1)}
+              placeholder="dd/mm/aaaa"
+              style={input}
+            />
+          </div>
+          <div>
+            <label>Resultado</label>
+            <input
+              ref={(el) => (camposRef.current[2] = el)}
+              value={resultado}
+              onChange={(e) => setResultado(e.target.value)}
+              onKeyDown={handleEnter(2)}
+              style={input}
+            />
+          </div>
+          <div>
+            <label>Anexo</label>
+            <input
+              ref={(el) => (camposRef.current[3] = el)}
+              type="file"
+              onChange={(e) => handleFile(e.target.files)}
+              onKeyDown={handleEnter(3)}
+              style={input}
+              accept="image/*,application/pdf"
+            />
+          </div>
+          <div>
+            <label>Responsável</label>
+            <input
+              ref={(el) => (camposRef.current[4] = el)}
+              value={responsavel}
+              onChange={(e) => setResponsavel(e.target.value)}
+              onKeyDown={handleEnter(4)}
+              style={input}
+            />
+          </div>
+          <div style={{ gridColumn: '1 / -1' }}>
+            <label>Observações</label>
+            <textarea
+              ref={(el) => (camposRef.current[5] = el)}
+              value={observacoes}
+              onChange={(e) => setObservacoes(e.target.value)}
+              onKeyDown={handleEnter(5)}
+              style={{ ...input, height: '80px' }}
+            />
+          </div>
+        </div>
+        <div style={rodape}>
+          <button onClick={onFechar} className="botao-cancelar">Cancelar</button>
+          <button onClick={salvar} className="botao-acao">Salvar</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const overlay = { position: 'fixed', inset: 0, backgroundColor: 'rgba(0,0,0,0.6)', display: 'flex', justifyContent: 'center', alignItems: 'center', zIndex: 1000 };
+const modal = { background: '#fff', borderRadius: '1rem', width: 'min(90vw, 600px)', maxHeight: '90vh', overflowY: 'auto', display: 'flex', flexDirection: 'column' };
+const header = { background: '#1e40af', color: 'white', padding: '1rem', fontWeight: 'bold', fontSize: '1.1rem', textAlign: 'center' };
+const conteudo = { padding: '1rem', display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '1rem' };
+const rodape = { display: 'flex', justifyContent: 'flex-end', gap: '1rem', padding: '1rem' };
+const input = { width: '100%', padding: '0.6rem', border: '1px solid #ccc', borderRadius: '0.5rem', fontSize: '0.95rem' };

--- a/src/pages/Saude/TabelaExames.jsx
+++ b/src/pages/Saude/TabelaExames.jsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import '../../styles/tabelaModerna.css';
+
+const resultadoAlterado = (res) => {
+  if (!res) return false;
+  const txt = String(res).toLowerCase();
+  if (txt.includes('alto') || txt.includes('alta')) return true;
+  if (txt.includes('baixo') || txt.includes('baixa')) return true;
+  if (txt.includes('positivo')) return true;
+  const num = parseFloat(txt.replace(',', '.'));
+  return !isNaN(num) && (num < 0 || num > 100);
+};
+
+export default function TabelaExames({ lista = [], onEditar, onExcluir, abrirAnexo }) {
+  const titulos = ['Tipo', 'Data', 'Resultado', 'Anexo', 'Responsável', 'Observações', 'Ações'];
+
+  return (
+    <div style={{ overflowX: 'auto' }}>
+      <table className="tabela-padrao">
+        <thead>
+          <tr>
+            {titulos.map((t, i) => (
+              <th key={i}>{t}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {lista.length === 0 ? (
+            <tr>
+              <td colSpan={titulos.length} style={{ textAlign: 'center', padding: '1rem' }}>
+                Nenhum exame registrado.
+              </td>
+            </tr>
+          ) : (
+            lista.map((e, idx) => (
+              <tr key={idx}>
+                <td>{e.tipo}</td>
+                <td>{e.data}</td>
+                <td>
+                  {resultadoAlterado(e.resultado) && <span title="Resultado alterado" style={{ color: 'red', marginRight: '0.25rem' }}>🔴</span>}
+                  {e.resultado}
+                </td>
+                <td>{e.anexos && e.anexos.length ? (
+                  <button onClick={() => abrirAnexo && abrirAnexo(e.anexos)} title="Abrir anexo">📎</button>
+                ) : '—'}</td>
+                <td>{e.responsavel}</td>
+                <td>{e.observacoes}</td>
+                <td className="coluna-acoes">
+                  <div className="botoes-tabela">
+                    {onEditar && <button className="botao-editar" onClick={() => onEditar(e, idx)}>✏️</button>}
+                    {onExcluir && <button className="botao-excluir" onClick={() => onExcluir(idx)}>🗑️</button>}
+                  </div>
+                </td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add TabelaExames component
- add ModalExame for new/edit exam records
- integrate "Exames" tab into ModalSaudeAnimal with localStorage persistence

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875b592d04c8328bc231d8d4c579901