### PR TITLE
Implement signup plan selection

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -9,7 +9,7 @@ const SECRET = process.env.JWT_SECRET || 'segredo';
 
 // ➤ Cadastro inicial: gera código e envia por e-mail
 async function cadastro(req, res) {
-  const { nome, nomeFazenda, email: endereco, telefone, senha } = req.body;
+  const { nome, nomeFazenda, email: endereco, telefone, senha, plano, formaPagamento } = req.body;
   const codigo = Math.floor(100000 + Math.random() * 900000).toString();
   const agora = new Date().toISOString();
 
@@ -40,6 +40,8 @@ async function cadastro(req, res) {
         nomeFazenda,
         telefone,
         senha: hash,
+        planoSolicitado: plano,
+        formaPagamento,
         criado_em: agora,
       });
     } else {
@@ -50,6 +52,8 @@ async function cadastro(req, res) {
         nomeFazenda,
         telefone,
         senha: hash,
+        planoSolicitado: plano,
+        formaPagamento,
         criado_em: agora,
       });
     }
@@ -107,11 +111,9 @@ async function verificarEmail(req, res) {
       perfil,
     });
 
-    const fimTeste = new Date();
-    fimTeste.setDate(fimTeste.getDate() + 14);
     db.prepare(
-      'UPDATE usuarios SET status = ?, dataFimTeste = ? WHERE id = ?'
-    ).run('teste', fimTeste.toISOString(), novo.id);
+      'UPDATE usuarios SET status = ?, planoSolicitado = ?, formaPagamento = ? WHERE id = ?'
+    ).run('pendente', pendente.planoSolicitado, pendente.formaPagamento, novo.id);
 
     VerificacaoPendente.deleteByEmail(db, endereco);
     res.json({ sucesso: true });

--- a/backend/db.js
+++ b/backend/db.js
@@ -44,6 +44,8 @@ const createVerificacoesPendentes = `CREATE TABLE IF NOT EXISTS verificacoes_pen
   nomeFazenda TEXT,
   telefone TEXT,
   senha TEXT,
+  planoSolicitado TEXT,
+  formaPagamento TEXT,
   criado_em DATETIME
 )`;
 
@@ -185,6 +187,14 @@ function applyMigrations(database) {
   database.exec(createProdutores);
   database.exec(createFazendas);
   database.exec(createMetodosPagamento);
+
+  let pendCols = database.prepare('PRAGMA table_info(verificacoes_pendentes)').all();
+  if (!pendCols.some(c => c.name === 'planoSolicitado')) {
+    database.exec("ALTER TABLE verificacoes_pendentes ADD COLUMN planoSolicitado TEXT");
+  }
+  if (!pendCols.some(c => c.name === 'formaPagamento')) {
+    database.exec("ALTER TABLE verificacoes_pendentes ADD COLUMN formaPagamento TEXT");
+  }
 
   let produtorCols = database.prepare('PRAGMA table_info(produtores)').all();
   if (!produtorCols.some(c => c.name === 'status')) {

--- a/backend/models/VerificacaoPendente.js
+++ b/backend/models/VerificacaoPendente.js
@@ -4,8 +4,9 @@
 function create(db, dados) {
   const stmt = db.prepare(`
     INSERT INTO verificacoes_pendentes (
-      email, codigo, nome, nomeFazenda, telefone, senha, criado_em
-    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      email, codigo, nome, nomeFazenda, telefone, senha,
+      planoSolicitado, formaPagamento, criado_em
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
   `);
 
   const info = stmt.run(
@@ -15,6 +16,8 @@ function create(db, dados) {
     dados.nomeFazenda,
     dados.telefone,
     dados.senha,
+    dados.planoSolicitado,
+    dados.formaPagamento,
     dados.criado_em
   );
 
@@ -41,7 +44,8 @@ function getAll(db) {
 function updateByEmail(db, email, dados) {
   db.prepare(`
     UPDATE verificacoes_pendentes
-    SET codigo = ?, nome = ?, nomeFazenda = ?, telefone = ?, senha = ?, criado_em = ?
+    SET codigo = ?, nome = ?, nomeFazenda = ?, telefone = ?, senha = ?,
+        planoSolicitado = ?, formaPagamento = ?, criado_em = ?
     WHERE email = ?
   `).run(
     dados.codigo,
@@ -49,6 +53,8 @@ function updateByEmail(db, email, dados) {
     dados.nomeFazenda,
     dados.telefone,
     dados.senha,
+    dados.planoSolicitado,
+    dados.formaPagamento,
     dados.criado_em,
     email
   );

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -64,7 +64,7 @@ router.get('/admin/planos', async (req, res) => {
     const email = unsanitizeEmail(dir);
     const db = initDB(email);
     const usuarios = db.prepare(`
-      SELECT id, nome, email, plano, planoSolicitado, formaPagamento, status, dataLiberado, dataFimLiberacao
+      SELECT id, nome, email, telefone, plano, planoSolicitado, formaPagamento, status, dataLiberado, dataFimLiberacao
       FROM usuarios WHERE perfil != 'admin'
     `).all();
 

--- a/src/layout/NavegacaoPrincipal.jsx
+++ b/src/layout/NavegacaoPrincipal.jsx
@@ -37,7 +37,6 @@ export default function NavegacaoPrincipal() {
     { id: 'financeiro', label: 'FINANCEIRO', icone: '/icones/financeiro.png', title: 'Relatórios financeiros', visivelPara: ['admin', 'funcionario'] },
     { id: 'calendario', label: 'CALENDÁRIO', icone: '/icones/calendario.png', title: 'Agenda de atividades', visivelPara: ['admin', 'funcionario'] },
     { id: 'ajustes', label: 'AJUSTES', icone: '/icones/indicadores.png', title: 'Configurações do sistema', visivelPara: ['admin', 'funcionario'] },
-    { id: 'planos', label: 'PLANOS', icone: '/icones/indicadores.png', title: 'Escolher plano', visivelPara: ['admin', 'funcionario'] },
     { id: 'admin', label: 'ADMIN', icone: '/icones/indicadores.png', title: 'Painel administrativo', visivelPara: ['admin'] },
     { id: 'painel-admin-planos', label: 'PLANOS', icone: '/icones/indicadores.png', title: 'Gestão de planos', visivelPara: ['admin'] },
     { id: 'relatorio-admin', label: 'RELATÓRIOS', icone: '/icones/relatorios.png', title: 'Relatórios administrativos', visivelPara: ['admin'] },

--- a/src/pages/Auth/Cadastro.jsx
+++ b/src/pages/Auth/Cadastro.jsx
@@ -11,6 +11,8 @@ export default function Cadastro() {
     telefone: '',
     senha: '',
     confirmar: '',
+    plano: 'basico',
+    formaPagamento: 'pix',
   });
   const [erro, setErro] = useState('');
   const [mostrarSenha, setMostrarSenha] = useState(false);
@@ -48,6 +50,8 @@ export default function Cadastro() {
         email: form.email,
         telefone: form.telefone,
         senha: form.senha,
+        plano: form.plano,
+        formaPagamento: form.formaPagamento,
       });
       localStorage.setItem('emailCadastro', form.email);
       localStorage.setItem('dadosCadastro', JSON.stringify({
@@ -56,6 +60,8 @@ export default function Cadastro() {
         email: form.email,
         telefone: form.telefone,
         senha: form.senha,
+        plano: form.plano,
+        formaPagamento: form.formaPagamento,
       }));
       navigate('/verificar-email');
     } catch (err) {
@@ -182,6 +188,30 @@ export default function Cadastro() {
                 {mostrarConfirmar ? <EyeOff size={18} /> : <Eye size={18} />}
               </button>
             </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Plano</label>
+            <select
+              className="border rounded w-full p-2"
+              value={form.plano}
+              onChange={(e) => setForm({ ...form, plano: e.target.value })}
+            >
+              <option value="basico">Básico</option>
+              <option value="intermediario">Intermediário</option>
+              <option value="completo">Completo</option>
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Forma de Pagamento</label>
+            <select
+              className="border rounded w-full p-2"
+              value={form.formaPagamento}
+              onChange={(e) => setForm({ ...form, formaPagamento: e.target.value })}
+            >
+              <option value="pix">Pix</option>
+              <option value="cartao">Cartão</option>
+              <option value="boleto">Boleto</option>
+            </select>
           </div>
           <button
             type="submit"

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -74,8 +74,7 @@ const routes = createRoutesFromElements(
     <Route path="/fazenda" element={<Fazenda />} />
     <Route path="/painel" element={<Fazenda />} />
     <Route path="/configuracoes-inicial" element={<ConfigTelaInicial />} />
-    <Route path="/escolher-plano" element={<RotaProtegida><EscolherPlano /></RotaProtegida>} />
-    <Route path="/planos" element={<RotaProtegida><EscolherPlanoUsuario /></RotaProtegida>} />
+    {/* Seleção de plano agora ocorre no cadastro */}
     <Route path="/status-plano" element={<RotaProtegida><StatusPlanoUsuario /></RotaProtegida>} />
 
     <Route path="/logout" element={<Logout />} />


### PR DESCRIPTION
## Summary
- hide Planos menu entry and route
- extend verificacao pendente table with plan and payment
- persist plan info during signup and verification
- show phone info in admin panel

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877bf7401fc8328966b2ed98fcb257c