### PR TITLE
Implement plan selection after email verification

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -30,6 +30,7 @@ const createUsuarios = `CREATE TABLE IF NOT EXISTS usuarios (
   plano TEXT DEFAULT 'gratis',
   planoSolicitado TEXT DEFAULT NULL,
   formaPagamento TEXT DEFAULT NULL,
+  dataCadastro TEXT DEFAULT NULL,
   metodoPagamentoId INTEGER,
   dataLiberado TEXT DEFAULT NULL,
   dataFimLiberacao TEXT DEFAULT NULL,
@@ -296,6 +297,9 @@ function applyMigrations(database) {
   }
   if (!usuarioCols.some(c => c.name === 'formaPagamento')) {
     database.exec('ALTER TABLE usuarios ADD COLUMN formaPagamento TEXT DEFAULT NULL');
+  }
+  if (!usuarioCols.some(c => c.name === 'dataCadastro')) {
+    database.exec('ALTER TABLE usuarios ADD COLUMN dataCadastro TEXT DEFAULT NULL');
   }
   if (!usuarioCols.some(c => c.name === 'metodoPagamentoId')) {
     database.exec('ALTER TABLE usuarios ADD COLUMN metodoPagamentoId INTEGER');

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -12,6 +12,7 @@ router.post('/register', controller.cadastro); // alias /auth/register
 router.post('/verificar-email', controller.verificarEmail);
 router.post('/verify-code', controller.verificarCodigo); // alias /auth/verify-code
 router.post('/forgot-password', controller.solicitarReset); // envia codigo de reset
+router.post('/finalizar-cadastro', controller.finalizarCadastro);
 
 // ✅ Login (só funciona após verificação do e-mail)
 router.post('/login', controller.login);

--- a/src/pages/Auth/Cadastro.jsx
+++ b/src/pages/Auth/Cadastro.jsx
@@ -11,8 +11,6 @@ export default function Cadastro() {
     telefone: '',
     senha: '',
     confirmar: '',
-    plano: 'basico',
-    formaPagamento: 'pix',
   });
   const [erro, setErro] = useState('');
   const [mostrarSenha, setMostrarSenha] = useState(false);
@@ -50,19 +48,18 @@ export default function Cadastro() {
         email: form.email,
         telefone: form.telefone,
         senha: form.senha,
-        plano: form.plano,
-        formaPagamento: form.formaPagamento,
       });
       localStorage.setItem('emailCadastro', form.email);
-      localStorage.setItem('dadosCadastro', JSON.stringify({
-        nome: form.nome,
-        nomeFazenda: form.fazenda,
-        email: form.email,
-        telefone: form.telefone,
-        senha: form.senha,
-        plano: form.plano,
-        formaPagamento: form.formaPagamento,
-      }));
+      localStorage.setItem(
+        'dadosCadastro',
+        JSON.stringify({
+          nome: form.nome,
+          nomeFazenda: form.fazenda,
+          email: form.email,
+          telefone: form.telefone,
+          senha: form.senha,
+        })
+      );
       navigate('/verificar-email');
     } catch (err) {
       setErro(err.response?.data?.message || 'Erro ao cadastrar');
@@ -188,30 +185,6 @@ export default function Cadastro() {
                 {mostrarConfirmar ? <EyeOff size={18} /> : <Eye size={18} />}
               </button>
             </div>
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Plano</label>
-            <select
-              className="border rounded w-full p-2"
-              value={form.plano}
-              onChange={(e) => setForm({ ...form, plano: e.target.value })}
-            >
-              <option value="basico">Básico</option>
-              <option value="intermediario">Intermediário</option>
-              <option value="completo">Completo</option>
-            </select>
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Forma de Pagamento</label>
-            <select
-              className="border rounded w-full p-2"
-              value={form.formaPagamento}
-              onChange={(e) => setForm({ ...form, formaPagamento: e.target.value })}
-            >
-              <option value="pix">Pix</option>
-              <option value="cartao">Cartão</option>
-              <option value="boleto">Boleto</option>
-            </select>
           </div>
           <button
             type="submit"

--- a/src/pages/Auth/VerificarEmail.jsx
+++ b/src/pages/Auth/VerificarEmail.jsx
@@ -59,9 +59,10 @@ export default function VerificarEmail() {
 
       if (res.data?.sucesso) {
         alert('E-mail verificado com sucesso!');
-        localStorage.removeItem('emailCadastro');
-        localStorage.removeItem('dadosCadastro');
-        navigate('/login');
+        if (res.data.token) {
+          localStorage.setItem('tokenCadastro', res.data.token);
+        }
+        navigate('/escolher-plano');
       } else {
         alert('Código incorreto ou expirado.');
       }

--- a/src/pages/EscolherPlanoCadastro.jsx
+++ b/src/pages/EscolherPlanoCadastro.jsx
@@ -1,0 +1,103 @@
+import { useState } from 'react';
+import { Star, Rocket, Crown, Gift } from 'lucide-react';
+import api from '../api';
+import ModalPlanoSelecionado from '../components/ModalPlanoSelecionado';
+import { useNavigate } from 'react-router-dom';
+
+export default function EscolherPlanoCadastro() {
+  const planos = [
+    {
+      id: 'teste_gratis',
+      nome: 'Teste Grátis',
+      descricao: 'Aproveite 7 dias gratuitamente',
+      Icon: Gift,
+    },
+    { id: 'basico', nome: 'Básico', descricao: 'Funcionalidades essenciais', Icon: Star },
+    {
+      id: 'intermediario',
+      nome: 'Intermediário',
+      descricao: 'Inclui controle de bezerras, reprodução e estoque',
+      Icon: Rocket,
+    },
+    {
+      id: 'completo',
+      nome: 'Completo',
+      descricao: 'Tudo do intermediário + relatórios e gráficos avançados',
+      Icon: Crown,
+    },
+  ];
+
+  const [planoSelecionado, setPlanoSelecionado] = useState(null);
+  const [enviando, setEnviando] = useState(false);
+  const navigate = useNavigate();
+
+  const finalizar = async (formaPagamento) => {
+    if (!planoSelecionado) return;
+    setEnviando(true);
+    try {
+      const token = localStorage.getItem('tokenCadastro');
+      await api.post('/auth/finalizar-cadastro', {
+        token,
+        plano: planoSelecionado.id,
+        formaPagamento,
+      });
+      alert('Cadastro finalizado. Aguarde aprovação.');
+      localStorage.removeItem('tokenCadastro');
+      localStorage.removeItem('emailCadastro');
+      localStorage.removeItem('dadosCadastro');
+      navigate('/login');
+    } catch (err) {
+      alert(
+        err.response?.data?.erro || err.response?.data?.error || 'Erro ao finalizar cadastro'
+      );
+    } finally {
+      setEnviando(false);
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto p-6 space-y-6">
+      <h1 className="text-xl font-bold text-center">Escolha seu Plano</h1>
+      <p className="text-center text-sm">Selecione o plano desejado para concluir o cadastro.</p>
+
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        {planos.map((p) => (
+          <div
+            key={p.id}
+            className="border rounded-lg shadow-sm p-4 flex flex-col items-center text-center space-y-2 hover:shadow-md transition cursor-pointer"
+            onClick={() => setPlanoSelecionado(p)}
+          >
+            <p.Icon size={36} className="text-blue-600" />
+            <h2 className="text-lg font-semibold">{p.nome}</h2>
+            <p className="text-sm flex-1">{p.descricao}</p>
+            <span className="text-sm font-medium text-blue-600">Selecionar</span>
+          </div>
+        ))}
+      </div>
+
+      {planoSelecionado && planoSelecionado.id !== 'teste_gratis' && (
+        <ModalPlanoSelecionado
+          plano={planoSelecionado}
+          onFechar={() => setPlanoSelecionado(null)}
+          onConfirmar={finalizar}
+        />
+      )}
+
+      {planoSelecionado && planoSelecionado.id === 'teste_gratis' && (
+        <div className="text-center space-y-4">
+          <p>Você selecionou o teste grátis por 7 dias.</p>
+          <button
+            className="botao-acao"
+            disabled={enviando}
+            onClick={() => finalizar(null)}
+          >
+            Confirmar
+          </button>
+          <button className="botao-cancelar" onClick={() => setPlanoSelecionado(null)}>
+            Cancelar
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -36,6 +36,7 @@ import ConfigTelaInicial from './pages/ConfigTelaInicial';
 
 import EscolherPlano from './pages/EscolherPlano';
 import EscolherPlanoUsuario from './pages/EscolherPlanoUsuario';
+import EscolherPlanoCadastro from './pages/EscolherPlanoCadastro';
 import StatusPlanoUsuario from './pages/StatusPlanoUsuario';
 
 const routes = createRoutesFromElements(
@@ -59,6 +60,7 @@ const routes = createRoutesFromElements(
 
     <Route path="/cadastro" element={<Cadastro />} />
     <Route path="/verificar-email" element={<VerificarEmail />} />
+    <Route path="/escolher-plano" element={<EscolherPlanoCadastro />} />
     <Route path="/login" element={<Login />} />
     <Route path="/esqueci-senha" element={<EsqueciSenha />} />
     <Route path="/bemvindo" element={<BemVindo />} />


### PR DESCRIPTION
## Summary
- adjust user creation flow to verify email then finalize with a plan
- add `dataCadastro` to the user table and migrations
- block login when account status is not active
- update routes and add new page for choosing plan during signup
- adjust existing signup and verification pages

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68790a5d99088328a5ac3c614b5824d2