### PR TITLE
Implement plan choice before sign up

### DIFF
--- a/src/pages/Auth/Cadastro.jsx
+++ b/src/pages/Auth/Cadastro.jsx
@@ -1,6 +1,6 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Eye, EyeOff } from 'lucide-react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import api from '../../api';
 
 export default function Cadastro() {
@@ -11,11 +11,21 @@ export default function Cadastro() {
     telefone: '',
     senha: '',
     confirmar: '',
+    plano: '',
+    formaPagamento: 'pix',
   });
   const [erro, setErro] = useState('');
   const [mostrarSenha, setMostrarSenha] = useState(false);
   const [mostrarConfirmar, setMostrarConfirmar] = useState(false);
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+
+  useEffect(() => {
+    const plano = searchParams.get('plano');
+    if (plano) {
+      setForm((f) => ({ ...f, plano }));
+    }
+  }, [searchParams]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();
@@ -48,6 +58,8 @@ export default function Cadastro() {
         email: form.email,
         telefone: form.telefone,
         senha: form.senha,
+        plano: form.plano,
+        formaPagamento: form.plano === 'teste_gratis' ? null : form.formaPagamento,
       });
       localStorage.setItem('emailCadastro', form.email);
       localStorage.setItem(
@@ -58,6 +70,8 @@ export default function Cadastro() {
           email: form.email,
           telefone: form.telefone,
           senha: form.senha,
+          plano: form.plano,
+          formaPagamento: form.formaPagamento,
         })
       );
       navigate('/verificar-email');
@@ -186,6 +200,29 @@ export default function Cadastro() {
               </button>
             </div>
           </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Plano</label>
+            <input
+              type="text"
+              value={form.plano}
+              readOnly
+              className="input-senha bg-gray-100 cursor-not-allowed"
+            />
+          </div>
+          {form.plano && form.plano !== 'teste_gratis' && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Forma de Pagamento</label>
+              <select
+                className="border rounded w-full p-2"
+                value={form.formaPagamento}
+                onChange={(e) => setForm({ ...form, formaPagamento: e.target.value })}
+              >
+                <option value="pix">Pix</option>
+                <option value="boleto">Boleto</option>
+                <option value="cartao">Cartão</option>
+              </select>
+            </div>
+          )}
           <button
             type="submit"
             style={{

--- a/src/pages/Auth/VerificarEmail.jsx
+++ b/src/pages/Auth/VerificarEmail.jsx
@@ -61,8 +61,10 @@ export default function VerificarEmail() {
         alert('E-mail verificado com sucesso!');
         if (res.data.token) {
           localStorage.setItem('tokenCadastro', res.data.token);
+          navigate('/escolher-plano-finalizar');
+        } else {
+          navigate('/login');
         }
-        navigate('/escolher-plano');
       } else {
         alert('Código incorreto ou expirado.');
       }

--- a/src/pages/EscolherPlanoInicio.jsx
+++ b/src/pages/EscolherPlanoInicio.jsx
@@ -1,0 +1,64 @@
+import { useNavigate } from 'react-router-dom';
+
+export default function EscolherPlanoInicio() {
+  const planos = [
+    {
+      id: 'teste_gratis',
+      nome: 'Teste',
+      preco: 'R$0',
+      recursos: ['Acesso por 7 dias'],
+    },
+    {
+      id: 'basico',
+      nome: 'Básico',
+      preco: 'R$29',
+      recursos: ['Suporte simples', 'Até 2 usuários'],
+    },
+    {
+      id: 'intermediario',
+      nome: 'Intermediário',
+      preco: 'R$59',
+      recursos: ['Suporte completo', '5 usuários', 'Controle de bezerras'],
+    },
+    {
+      id: 'completo',
+      nome: 'Completo',
+      preco: 'R$89',
+      recursos: ['Todos os recursos disponíveis'],
+    },
+  ];
+
+  const navigate = useNavigate();
+
+  const escolher = (id) => {
+    navigate(`/cadastro?plano=${id}`);
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto p-6 space-y-6">
+      <h1 className="text-xl font-bold text-center">Escolha seu Plano</h1>
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        {planos.map((p) => (
+          <div
+            key={p.id}
+            className="border rounded-lg shadow-sm p-4 flex flex-col items-center text-center space-y-2"
+          >
+            <h2 className="text-lg font-semibold">{p.nome}</h2>
+            <div className="font-bold">{p.preco}</div>
+            <ul className="text-sm flex-1 list-disc pl-4">
+              {p.recursos.map((r) => (
+                <li key={r}>{r}</li>
+              ))}
+            </ul>
+            <button
+              className="botao-acao mt-2"
+              onClick={() => escolher(p.id)}
+            >
+              Escolher este plano
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -34,7 +34,7 @@ import RotaAdmin from './utils/RotaAdmin';
 import Fazenda from './pages/Fazenda/Fazenda';
 import ConfigTelaInicial from './pages/ConfigTelaInicial';
 
-import EscolherPlano from './pages/EscolherPlano';
+import EscolherPlanoInicio from './pages/EscolherPlanoInicio';
 import EscolherPlanoUsuario from './pages/EscolherPlanoUsuario';
 import EscolherPlanoCadastro from './pages/EscolherPlanoCadastro';
 import StatusPlanoUsuario from './pages/StatusPlanoUsuario';
@@ -60,7 +60,8 @@ const routes = createRoutesFromElements(
 
     <Route path="/cadastro" element={<Cadastro />} />
     <Route path="/verificar-email" element={<VerificarEmail />} />
-    <Route path="/escolher-plano" element={<EscolherPlanoCadastro />} />
+    <Route path="/escolher-plano" element={<EscolherPlanoInicio />} />
+    <Route path="/escolher-plano-finalizar" element={<EscolherPlanoCadastro />} />
     <Route path="/login" element={<Login />} />
     <Route path="/esqueci-senha" element={<EsqueciSenha />} />
     <Route path="/bemvindo" element={<BemVindo />} />


### PR DESCRIPTION
## Summary
- add new `EscolherPlanoInicio` page with plan cards
- preload plan on `Cadastro` using query param and show payment form for paid plans
- adjust verify email flow to finish signup when a plan was selected earlier
- update routes to use the new plan selection page

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687913fa424c8328a9cdf540e88a3b74