### PR TITLE
Adiciona escolha de plano antes do cadastro

### DIFF
--- a/src/pages/Auth/Cadastro.jsx
+++ b/src/pages/Auth/Cadastro.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { Eye, EyeOff } from 'lucide-react';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams, Link } from 'react-router-dom';
 import api from '../../api';
 
 export default function Cadastro() {
@@ -200,15 +200,14 @@ export default function Cadastro() {
               </button>
             </div>
           </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Plano</label>
-            <input
-              type="text"
-              value={form.plano}
-              readOnly
-              className="input-senha bg-gray-100 cursor-not-allowed"
-            />
-          </div>
+          {form.plano && (
+            <div className="text-sm text-center">
+              Plano escolhido: <strong>{form.plano}</strong>{' '}
+              <Link to="/escolher-plano" className="text-blue-600 hover:underline">
+                Alterar plano
+              </Link>
+            </div>
+          )}
           {form.plano && form.plano !== 'teste_gratis' && (
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">Forma de Pagamento</label>

--- a/src/pages/Auth/Login.jsx
+++ b/src/pages/Auth/Login.jsx
@@ -253,7 +253,10 @@ if (isAdmin) {
 
               <p className="text-center text-sm text-gray-600 mt-4 font-light">
                 Não tem conta?{' '}
-                <Link to="/cadastro" className="text-blue-600 hover:underline">
+                <Link
+                  to="/escolher-plano"
+                  className="text-blue-600 hover:underline"
+                >
                   Cadastre-se
                 </Link>
               </p>

--- a/src/pages/EscolherPlanoInicio.jsx
+++ b/src/pages/EscolherPlanoInicio.jsx
@@ -35,29 +35,52 @@ export default function EscolherPlanoInicio() {
   };
 
   return (
-    <div className="max-w-4xl mx-auto p-6 space-y-6">
-      <h1 className="text-xl font-bold text-center">Escolha seu Plano</h1>
-      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        {planos.map((p) => (
-          <div
-            key={p.id}
-            className="border rounded-lg shadow-sm p-4 flex flex-col items-center text-center space-y-2"
-          >
-            <h2 className="text-lg font-semibold">{p.nome}</h2>
-            <div className="font-bold">{p.preco}</div>
-            <ul className="text-sm flex-1 list-disc pl-4">
-              {p.recursos.map((r) => (
-                <li key={r}>{r}</li>
-              ))}
-            </ul>
-            <button
-              className="botao-acao mt-2"
-              onClick={() => escolher(p.id)}
+    <div
+      style={{
+        minHeight: '100vh',
+        width: '100%',
+        overflow: 'hidden',
+        margin: 0,
+        padding: 0,
+        backgroundImage: "url('/icones/telafundo.png')",
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+        backgroundRepeat: 'no-repeat',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
+      <div
+        style={{
+          backgroundColor: 'rgba(255, 255, 255, 0.85)',
+          padding: '40px',
+          borderRadius: '20px',
+          boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
+          maxWidth: '800px',
+          width: '100%',
+        }}
+      >
+        <h1 className="text-xl font-bold text-center mb-4">Escolha seu Plano</h1>
+        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+          {planos.map((p) => (
+            <div
+              key={p.id}
+              className="border rounded-lg shadow-sm p-4 flex flex-col items-center text-center space-y-2"
             >
-              Escolher este plano
-            </button>
-          </div>
-        ))}
+              <h2 className="text-lg font-semibold">{p.nome}</h2>
+              <div className="font-bold">{p.preco}</div>
+              <ul className="text-sm flex-1 list-disc pl-4">
+                {p.recursos.map((r) => (
+                  <li key={r}>{r}</li>
+                ))}
+              </ul>
+              <button className="botao-acao mt-2" onClick={() => escolher(p.id)}>
+                Selecionar
+              </button>
+            </div>
+          ))}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- direciona link "Cadastre-se" para `/escolher-plano`
- aplica layout do login na tela de escolha de plano
- exibe plano escolhido e opção para alterar na tela de cadastro

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687925c85e048328931c2489484190bf