### PR TITLE
Fix registration flow routing

### DIFF
--- a/src/pages/Auth/Cadastro.jsx
+++ b/src/pages/Auth/Cadastro.jsx
@@ -22,10 +22,12 @@ export default function Cadastro() {
 
   useEffect(() => {
     const plano = searchParams.get('plano');
-    if (plano) {
+    if (!plano) {
+      navigate('/escolher-plano');
+    } else {
       setForm((f) => ({ ...f, plano }));
     }
-  }, [searchParams]);
+  }, [searchParams, navigate]);
 
   const handleSubmit = async (e) => {
     e.preventDefault();


### PR DESCRIPTION
## Summary
- redirect /cadastro to choose-plan when no plan is specified
- show sign up link to `/escolher-plano`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68792975f1508328b5273d922df767c0