### PR TITLE
Improve email verification flow

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -72,7 +72,9 @@ async function cadastro(req, res) {
       });
     }
 
-    await emailUtils.enviarCodigo(endereco, codigo);
+    emailUtils
+      .enviarCodigo(endereco, codigo)
+      .catch((err) => console.error('Erro ao enviar e-mail:', err));
     res.status(201).json({ message: 'Código enviado. Verifique o e-mail.' });
   } catch (error) {
     console.error('Erro no cadastro:', error);

--- a/src/pages/Auth/Cadastro.jsx
+++ b/src/pages/Auth/Cadastro.jsx
@@ -76,7 +76,7 @@ export default function Cadastro() {
           formaPagamento: form.formaPagamento,
         })
       );
-      navigate('/verificar-email');
+      navigate('/verificar-codigo');
     } catch (err) {
       setErro(err.response?.data?.message || 'Erro ao cadastrar');
     }

--- a/src/pages/Auth/VerificarEmail.jsx
+++ b/src/pages/Auth/VerificarEmail.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { Loader2 } from 'lucide-react';
 import api from '../../api';
 
 export default function VerificarEmail() {
@@ -8,6 +9,7 @@ export default function VerificarEmail() {
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [tempo, setTempo] = useState(180);
+  const [podeReenviar, setPodeReenviar] = useState(false);
 
   useEffect(() => {
     const salvo = localStorage.getItem('emailCadastro');
@@ -21,6 +23,11 @@ export default function VerificarEmail() {
       setTempo((t) => (t > 0 ? t - 1 : 0));
     }, 1000);
     return () => clearInterval(id);
+  }, []);
+
+  useEffect(() => {
+    const t = setTimeout(() => setPodeReenviar(true), 30000);
+    return () => clearTimeout(t);
   }, []);
 
   const formatarTempo = (seg) => {
@@ -38,6 +45,8 @@ export default function VerificarEmail() {
     try {
       await api.post('/auth/register', JSON.parse(dados));
       setTempo(180);
+      setPodeReenviar(false);
+      setTimeout(() => setPodeReenviar(true), 30000);
       alert('Código reenviado. Verifique seu e-mail.');
     } catch (err) {
       alert('Erro ao reenviar código.');
@@ -101,10 +110,14 @@ export default function VerificarEmail() {
           width: '100%',
         }}
       >
-        <p className="text-center mb-4">
-          Enviamos um código de verificação para seu e-mail. Digite o código
-          abaixo para confirmar sua conta.
+        <p className="text-center mb-2">
+          Enviamos um código para {email}. Isso pode levar alguns segundos...
         </p>
+        {!podeReenviar && (
+          <div className="flex justify-center mb-2">
+            <Loader2 className="animate-spin" />
+          </div>
+        )}
         {erro && (
           <div className="mb-2 text-red-600 text-sm text-center">{erro}</div>
         )}
@@ -142,7 +155,7 @@ export default function VerificarEmail() {
             Verificar
           </button>
         </form>
-        {tempo === 0 && (
+        {podeReenviar && (
           <button onClick={reenviarCodigo} className="mt-2 text-sm text-blue-600 hover:underline">Reenviar código</button>
         )}
       </div>

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -60,6 +60,7 @@ const routes = createRoutesFromElements(
 
     <Route path="/cadastro" element={<Cadastro />} />
     <Route path="/verificar-email" element={<VerificarEmail />} />
+    <Route path="/verificar-codigo" element={<VerificarEmail />} />
     <Route path="/escolher-plano" element={<EscolherPlanoInicio />} />
     <Route path="/escolher-plano-finalizar" element={<EscolherPlanoCadastro />} />
     <Route path="/login" element={<Login />} />


### PR DESCRIPTION
## Summary
- send sign-up email asynchronously to reduce wait
- navigate to `/verificar-codigo` after registration
- show code delivery message with loading spinner
- allow resending verification code after 30s
- support `/verificar-codigo` route

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687ba48e0430832895ac0597056a6d01