### PR TITLE
Melhora visual de seleção de plano

### DIFF
--- a/src/pages/EscolherPlano.css
+++ b/src/pages/EscolherPlano.css
@@ -1,0 +1,93 @@
+.pagina-escolher-plano {
+  min-height: 100vh;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background-image: url('/icones/telafundo.png');
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  padding: 20px;
+}
+
+.painel-planos {
+  background-color: rgba(255, 255, 255, 0.85);
+  padding: 40px;
+  border-radius: 20px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 1000px;
+}
+
+.painel-planos .titulo {
+  text-align: center;
+  font-size: 1.5rem;
+  font-weight: 600;
+  margin-bottom: 20px;
+}
+
+.grid-planos {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.card-plano-modern {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 16px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 20px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card-plano-modern:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.15);
+}
+
+.faixa-superior {
+  width: 100%;
+  height: 6px;
+  margin: -20px -20px 12px;
+  border-radius: 16px 16px 0 0;
+}
+
+.card-plano-modern h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.card-plano-modern .preco {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin: 10px 0;
+}
+
+.card-plano-modern .lista-beneficios {
+  flex: 1;
+  margin: 0 0 16px 0;
+  padding-left: 20px;
+  list-style: disc;
+  text-align: left;
+}
+
+.btn-escolher-moderno {
+  border: none;
+  color: #fff;
+  font-weight: 600;
+  padding: 0.6rem 1.2rem;
+  border-radius: 9999px;
+  cursor: pointer;
+  transition: filter 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn-escolher-moderno:hover {
+  filter: brightness(0.9);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+}

--- a/src/pages/EscolherPlanoInicio.jsx
+++ b/src/pages/EscolherPlanoInicio.jsx
@@ -1,29 +1,34 @@
 import { useNavigate } from 'react-router-dom';
+import './EscolherPlano.css';
 
 export default function EscolherPlanoInicio() {
   const planos = [
     {
       id: 'teste_gratis',
-      nome: 'Teste',
+      nome: 'Teste Grátis',
       preco: 'R$0',
+      cor: '#10b981',
       recursos: ['Acesso por 7 dias'],
     },
     {
       id: 'basico',
       nome: 'Básico',
       preco: 'R$29',
+      cor: '#3b82f6',
       recursos: ['Suporte simples', 'Até 2 usuários'],
     },
     {
       id: 'intermediario',
       nome: 'Intermediário',
       preco: 'R$59',
+      cor: '#f59e0b',
       recursos: ['Suporte completo', '5 usuários', 'Controle de bezerras'],
     },
     {
       id: 'completo',
       nome: 'Completo',
       preco: 'R$89',
+      cor: '#8b5cf6',
       recursos: ['Todos os recursos disponíveis'],
     },
   ];
@@ -35,47 +40,25 @@ export default function EscolherPlanoInicio() {
   };
 
   return (
-    <div
-      style={{
-        minHeight: '100vh',
-        width: '100%',
-        overflow: 'hidden',
-        margin: 0,
-        padding: 0,
-        backgroundImage: "url('/icones/telafundo.png')",
-        backgroundSize: 'cover',
-        backgroundPosition: 'center',
-        backgroundRepeat: 'no-repeat',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-      }}
-    >
-      <div
-        style={{
-          backgroundColor: 'rgba(255, 255, 255, 0.85)',
-          padding: '40px',
-          borderRadius: '20px',
-          boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
-          maxWidth: '800px',
-          width: '100%',
-        }}
-      >
-        <h1 className="text-xl font-bold text-center mb-4">Escolha seu Plano</h1>
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+    <div className="pagina-escolher-plano">
+      <div className="painel-planos">
+        <h1 className="titulo">Escolha seu Plano</h1>
+        <div className="grid-planos">
           {planos.map((p) => (
-            <div
-              key={p.id}
-              className="border rounded-lg shadow-sm p-4 flex flex-col items-center text-center space-y-2"
-            >
-              <h2 className="text-lg font-semibold">{p.nome}</h2>
-              <div className="font-bold">{p.preco}</div>
-              <ul className="text-sm flex-1 list-disc pl-4">
+            <div key={p.id} className="card-plano-modern">
+              <div className="faixa-superior" style={{ backgroundColor: p.cor }} />
+              <h2>{p.nome}</h2>
+              <div className="preco">{p.preco}</div>
+              <ul className="lista-beneficios">
                 {p.recursos.map((r) => (
                   <li key={r}>{r}</li>
                 ))}
               </ul>
-              <button className="botao-acao mt-2" onClick={() => escolher(p.id)}>
+              <button
+                className="btn-escolher-moderno"
+                style={{ backgroundColor: p.cor }}
+                onClick={() => escolher(p.id)}
+              >
                 Selecionar
               </button>
             </div>


### PR DESCRIPTION
## Summary
- add EscolherPlano.css with modern card layout
- refatore EscolherPlanoInicio.jsx para usar novos estilos de cards

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ba5c8c0cc8328b12cbe7a5085ae0d