### PR TITLE
Fix payment select dropdown behavior

### DIFF
--- a/src/pages/Auth/Cadastro.jsx
+++ b/src/pages/Auth/Cadastro.jsx
@@ -223,6 +223,8 @@ export default function Cadastro() {
                 placeholder="Escolha a forma de pagamento"
                 onChange={(selectedOption) => setFormaPagamento(selectedOption)}
                 value={formaPagamento}
+                menuPortalTarget={document.body}
+                menuPosition="fixed"
                 styles={{
                   control: (provided) => ({
                     ...provided,
@@ -236,6 +238,10 @@ export default function Cadastro() {
                   placeholder: (provided) => ({
                     ...provided,
                     color: '#999',
+                  }),
+                  menuPortal: (base) => ({
+                    ...base,
+                    zIndex: 9999,
                   }),
                 }}
               />
@@ -264,3 +270,4 @@ export default function Cadastro() {
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- update payment form select so dropdown always renders on top

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bac29add48328a560c398e6c0a2c2