### PR TITLE
Add phone mask and capitalize fields in cadastro

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "react-easy-crop": "^4.5.1",
     "react-router-dom": "^6.30.0",
     "react-select": "^5.10.1",
+    "react-input-mask": "^3.0.0",
     "react-toastify": "^11.0.5",
     "recharts": "^2.15.3",
     "sqlite3": "^5.1.7",

--- a/src/pages/Auth/Cadastro.jsx
+++ b/src/pages/Auth/Cadastro.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import Select from 'react-select';
+import InputMask from 'react-input-mask';
 import { Eye, EyeOff } from 'lucide-react';
 import { useNavigate, useSearchParams, Link } from 'react-router-dom';
 import api from '../../api';
@@ -130,6 +131,7 @@ export default function Cadastro() {
                 value={form.nome}
                 onChange={(e) => setForm({ ...form, nome: e.target.value })}
                 className="input-senha"
+                style={{ textTransform: 'capitalize' }}
               />
             </div>
           </div>
@@ -142,6 +144,7 @@ export default function Cadastro() {
                 value={form.fazenda}
                 onChange={(e) => setForm({ ...form, fazenda: e.target.value })}
                 className="input-senha"
+                style={{ textTransform: 'capitalize' }}
               />
             </div>
           </div>
@@ -160,14 +163,21 @@ export default function Cadastro() {
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Telefone</label>
             <div className="input-senha-container">
-              <input
-                type="tel"
-                placeholder="(99) 99999-9999"
+              <InputMask
+                mask="(99) 99999-9999"
                 value={form.telefone}
                 onChange={(e) => setForm({ ...form, telefone: e.target.value })}
-                required
-                className="input-senha"
-              />
+              >
+                {(inputProps) => (
+                  <input
+                    {...inputProps}
+                    type="text"
+                    placeholder="(99) 99999-9999"
+                    required
+                    className="input-senha"
+                  />
+                )}
+              </InputMask>
             </div>
           </div>
           <div>


### PR DESCRIPTION
## Summary
- use `react-input-mask` for phone field
- auto-capitalize producer and farm names
- declare react-input-mask dependency

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bb025fbe0832897b1f95953dc7d64