### PR TITLE
Fix admin initialization and port cleanup

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -366,7 +366,7 @@ module.exports = {
 };
 
 function inicializarAdmins(db) {
-  const admins = [
+  const adminsPadrao = [
     {
       nome: "Administrador",
       nomeFazenda: "Sistema",
@@ -374,23 +374,21 @@ function inicializarAdmins(db) {
       telefone: "",
       senha: "admin123",
       plano: "admin",
-      metodoPagamento: "nenhum"
-    }
+      metodoPagamento: "nenhum",
+    },
   ];
 
-  admins.forEach((admin) => {
-    try {
-      // Verifica se o admin já está cadastrado no banco
-      const jaExiste = Usuario.getByEmail(db, admin.email);
-
-      if (!jaExiste) {
+  adminsPadrao.forEach((admin) => {
+    const existente = Usuario.getByEmail(db, admin.email);
+    if (!existente) {
+      try {
         Usuario.create(db, admin);
         console.log(`✅ Admin criado: ${admin.email}`);
-      } else {
-        console.log(`ℹ️ Admin já existe no banco: ${admin.email}`);
+      } catch (err) {
+        console.error(`❌ Erro ao criar admin ${admin.email}:`, err.message);
       }
-    } catch (err) {
-      console.error(`❌ Erro ao inicializar admin: ${admin.email}`, err.message);
+    } else {
+      console.log(`ℹ️ Admin já existente: ${admin.email}`);
     }
   });
 }

--- a/start-tudo.js
+++ b/start-tudo.js
@@ -19,13 +19,25 @@ if (fs.existsSync(distPath)) {
 // 🔪 Mata processos da porta 3000
 try {
   const result = execSync('netstat -ano | findstr :3000').toString();
-  const pid = result.trim().split(/\s+/).pop();
-  if (pid && pid !== '0') {
-    execSync(`taskkill /PID ${pid} /F`);
-    console.log(`✔️ Finalizado processo na porta 3000 (PID ${pid})`);
-  }
+  const lines = result.trim().split('\n');
+  const pids = new Set();
+
+  lines.forEach((line) => {
+    const parts = line.trim().split(/\s+/);
+    const pid = parts[parts.length - 1];
+    if (pid !== '0') pids.add(pid);
+  });
+
+  pids.forEach((pid) => {
+    try {
+      execSync(`taskkill /PID ${pid} /F`);
+      console.log(`✔️ Processo na porta 3000 (PID ${pid}) finalizado.`);
+    } catch (e) {
+      console.log(`⚠️ Não foi possível finalizar PID ${pid}:`, e.message);
+    }
+  });
 } catch (err) {
-  console.log('ℹ️ Porta 3000 já estava liberada.');
+  console.log('ℹ️ Nenhum processo ocupando a porta 3000.');
 }
 
 // 🎯 Build do frontend


### PR DESCRIPTION
## Summary
- avoid crashing when default admin already exists
- skip PID 0 when killing port 3000 processes

## Testing
- `npm -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bca49373c8328a32fb1e3ed948bfc