### PR TITLE
Fix verification code handling

### DIFF
--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -11,7 +11,7 @@ router.post('/register', controller.cadastro); // alias /auth/register
 
 // ✅ Verifica o código enviado por e-mail e cria o usuário
 router.post('/verificar-email', controller.verificarEmail);
-router.post('/verify-code', controller.verificarCodigo); // alias /auth/verify-code
+router.post('/verify-code', controller.verifyCode); // alias /auth/verify-code
 router.post('/forgot-password', controller.solicitarReset); // envia codigo de reset
 router.post('/finalizar-cadastro', controller.finalizarCadastro);
 


### PR DESCRIPTION
## Summary
- implement new `verifyCode` for signup verification
- update auth routes to use the new handler

## Testing
- `node backend/server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6884fca39c40832889ce273eb76e76c4