### PR TITLE
Fix FichaComplementarAnimal import and increase body limit

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -26,7 +26,8 @@ const { initDB } = require('./db');
 
 const app = express();
 app.use(cors());
-app.use(express.json());
+// aumenta o limite de tamanho do JSON para aceitar PDFs codificados em Base64 (até 10 mb)
+app.use(express.json({ limit: '10mb' }));
 
 // 📁 Pasta para backups de dados excluídos
 fs.mkdirSync(path.join(__dirname, 'dadosExcluidos'), { recursive: true });

--- a/src/pages/Animais/FichaComplementarAnimal.jsx
+++ b/src/pages/Animais/FichaComplementarAnimal.jsx
@@ -2,7 +2,8 @@ import React, { useEffect, useRef, useState } from "react";
 import Select from "react-select";
 import ImportarFichaTouro from "./ImportarFichaTouro";
 import AbrirFichaTouro from "./AbrirFichaTouro";
-import { salvarFichaAnimalSQLite } from '../../utils/apiFuncoes.js';
+// importa também buscarTodosTourosSQLite, usado para carregar a lista de touros já cadastrados
+import { salvarFichaAnimalSQLite, buscarTodosTourosSQLite } from '../../utils/apiFuncoes.js';
 
 export default function FichaComplementarAnimal({ numeroAnimal, onFechar, onSalvar }) {
   const [nomeTouro, setNomeTouro] = useState("");


### PR DESCRIPTION
## Summary
- fix import in `FichaComplementarAnimal.jsx`
- allow up to 10mb JSON bodies in Express server

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-input-mask)*

------
https://chatgpt.com/codex/tasks/task_e_68864ecbaef48328876297e7018473a4