### PR TITLE
Expose /api/touros route

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -51,6 +51,7 @@ app.use('/examesSanitarios', examesRoutes);
 app.use('/api/racas', racasRoutes);
 // nova rota para fichas de touros (pai dos animais)
 app.use('/touros', tourosRoutes);
+app.use('/api/touros', tourosRoutes);
 app.use('/', mockRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api', rotasExtras);


### PR DESCRIPTION
## Summary
- expose `tourosRoutes` at `/api/touros` to match frontend requests

## Testing
- `node backend/server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688653766d1c83288296fe2d9470fdef