### PR TITLE
Add tipoSaida support for animal exit

### DIFF
--- a/backend/controllers/animaisController.js
+++ b/backend/controllers/animaisController.js
@@ -47,7 +47,11 @@ async function cadastrarAnimal(req, res) {
 async function editarAnimal(req, res) {
   const db = initDB(req.user.email);
   const id = req.params.id;
-  const dadosAtualizados = req.body;
+  const dadosAtualizados = {
+    ...req.body,
+    // garante que o tipo de saída seja enviado à camada de modelo
+    tipoSaida: req.body.tipoSaida ?? null,
+  };
 
   try {
     const animalAtualizado = animaisModel.update(db, id, dadosAtualizados, req.user.idProdutor);

--- a/src/pages/Animais/ConteudoSaidaAnimal.jsx
+++ b/src/pages/Animais/ConteudoSaidaAnimal.jsx
@@ -115,6 +115,8 @@ export default function ConteudoSaidaAnimal({ onAtualizar }) {
       dataSaida: novaSaida.data,
       valorVenda: novaSaida.valor,
       observacoesSaida: novaSaida.observacao,
+      // envia também o tipo de saída selecionado
+      tipoSaida: novaSaida.tipo,
     };
 
     await atualizarItem("animais", { ...dadosAtualizados, id: animal.id });

--- a/src/pages/Animais/utilsAnimais.js
+++ b/src/pages/Animais/utilsAnimais.js
@@ -124,6 +124,7 @@ export function migrarAnimal(a = {}) {
     dataSaida: null,
     valorVenda: null,
     observacoesSaida: null,
+    tipoSaida: null,
   };
 
   const historicoPadrao = {


### PR DESCRIPTION
## Summary
- persist `tipoSaida` when updating animals in backend
- send `tipoSaida` from exit registration screen
- include `tipoSaida` in local animal defaults

## Testing
- `npm run build` *(fails: vite not found)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688660ad98c48328b9935ea8bab77e76