### PR TITLE
Fix pre-parto and parto date parsing

### DIFF
--- a/src/pages/Animais/ConteudoParto.jsx
+++ b/src/pages/Animais/ConteudoParto.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import AcaoParto from './AcaoParto';
 import '../../styles/botoes.css';
 import '../../styles/tabelaModerna.css';
+import parseBRDate from '@/utils/parseBRDate';
 
 export default function ConteudoParto({ vacas = [] }) {
   const [colunasVisiveis, setColunasVisiveis] = useState({
@@ -27,12 +28,11 @@ export default function ConteudoParto({ vacas = [] }) {
       return false;
     }
 
-    const [dia, mes, ano] = v.dataPrevistaParto.split('/').map(Number);
-    const previsao = new Date(ano, mes - 1, dia);
-    const diasParaParto = (previsao - hoje) / (1000 * 60 * 60 * 24);
+    const previsao = parseBRDate(v.dataPrevistaParto);
+    const diasParaParto = previsao ? (previsao - hoje) / (1000 * 60 * 60 * 24) : 0;
 
     // Exibir se o parto estiver atrasado ou previsto para os próximos 10 dias
-    return diasParaParto <= 10 || previsao <= hoje;
+    return previsao && (diasParaParto <= 10 || previsao <= hoje);
   });
 
   const abrirModalParto = (vaca) => {

--- a/src/pages/Animais/ConteudoPreParto.jsx
+++ b/src/pages/Animais/ConteudoPreParto.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import '../../styles/tabelaModerna.css';
 import '../../styles/botoes.css';
+import parseBRDate from '@/utils/parseBRDate';
 
 export default function ConteudoPreParto({ vacas }) {
   const [diasAntes, setDiasAntes] = useState(5);
@@ -29,9 +30,8 @@ export default function ConteudoPreParto({ vacas }) {
   const vacasFiltradas = (Array.isArray(vacas) ? vacas : []).filter(v => {
     if ((v.sexo || "").toLowerCase() !== "femea" || !v.dataPrevistaParto) return false;
     if (v.status === "lactacao") return false; // Evita mostrar vacas que já pariram
-    const [dia, mes, ano] = v.dataPrevistaParto.split("/").map(Number);
-    const dataParto = new Date(ano, mes - 1, dia);
-    return dataParto <= dataLimite;
+    const dataParto = parseBRDate(v.dataPrevistaParto);
+    return dataParto && dataParto <= dataLimite;
   });
 
   const alternarColuna = (coluna) => {

--- a/src/utils/parseBRDate.js
+++ b/src/utils/parseBRDate.js
@@ -1,0 +1,5 @@
+export default function parseBRDate(dataStr) {
+  if (!dataStr) return null;
+  const [dia, mes, ano] = dataStr.split('/');
+  return new Date(ano, mes - 1, dia);
+}


### PR DESCRIPTION
## Summary
- handle Brazilian date format with a new `parseBRDate` helper
- use the helper in `ConteudoPreParto` and `ConteudoParto` lists

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6886c896d1f08328b54454e769fe242f