### PR TITLE
Integra rotas de eventos no frontend

### DIFF
--- a/src/pages/Animais/ConteudoParto.jsx
+++ b/src/pages/Animais/ConteudoParto.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import AcaoParto from './AcaoParto';
 import '../../styles/botoes.css';
 import '../../styles/tabelaModerna.css';
-import parseBRDate from '@/utils/parseBRDate';
+import { parseBRDate, diffDias } from '@/utils/dateUtils';
 
 export default function ConteudoParto({ vacas = [] }) {
   const [colunasVisiveis, setColunasVisiveis] = useState({
@@ -17,22 +17,10 @@ export default function ConteudoParto({ vacas = [] }) {
   const [mostrarInfo, setMostrarInfo] = useState(false);
 
   // ⏬ Atualiza local ao montar e após evento de parto
-  const hoje = new Date();
-
   const vacasFiltradas = (Array.isArray(vacas) ? vacas : []).filter(v => {
-    if ((v.sexo || '').toLowerCase() !== 'femea') {
-      return false;
-    }
-
-    if (!v.dataPrevistaParto) {
-      return false;
-    }
-
     const previsao = parseBRDate(v.dataPrevistaParto);
-    const diasParaParto = previsao ? (previsao - hoje) / (1000 * 60 * 60 * 24) : 0;
-
-    // Exibir se o parto estiver atrasado ou previsto para os próximos 10 dias
-    return previsao && (diasParaParto <= 10 || previsao <= hoje);
+    const dif = previsao ? diffDias(previsao) : null;
+    return v.status === 1 && dif !== null && dif <= 0;
   });
 
   const abrirModalParto = (vaca) => {

--- a/src/pages/Animais/ConteudoPreParto.jsx
+++ b/src/pages/Animais/ConteudoPreParto.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import '../../styles/tabelaModerna.css';
 import '../../styles/botoes.css';
-import parseBRDate from '@/utils/parseBRDate';
+import { parseBRDate, diffDias } from '@/utils/dateUtils';
 
 export default function ConteudoPreParto({ vacas }) {
   const [diasAntes, setDiasAntes] = useState(5);
@@ -23,15 +23,10 @@ export default function ConteudoPreParto({ vacas }) {
   const [mostrarFiltros, setMostrarFiltros] = useState(false);
   const [colunaHover, setColunaHover] = useState(null);
 
-  const hoje = new Date();
-  const dataLimite = new Date();
-  dataLimite.setDate(hoje.getDate() + filtroDias);
-
   const vacasFiltradas = (Array.isArray(vacas) ? vacas : []).filter(v => {
-    if ((v.sexo || "").toLowerCase() !== "femea" || !v.dataPrevistaParto) return false;
-    if (v.status === "lactacao") return false; // Evita mostrar vacas que já pariram
     const dataParto = parseBRDate(v.dataPrevistaParto);
-    return dataParto && dataParto <= dataLimite;
+    const dias = dataParto ? diffDias(dataParto) : null;
+    return v.status === 1 && dias !== null && dias > 0 && dias <= filtroDias;
   });
 
   const alternarColuna = (coluna) => {

--- a/src/pages/Animais/ConteudoSecagem.jsx
+++ b/src/pages/Animais/ConteudoSecagem.jsx
@@ -49,7 +49,7 @@ export default function ConteudoSecagem({ vacas }) {
   };
 
   const vacasFiltradas = (Array.isArray(vacas) ? vacas : []).filter(
-    (v) => (v.sexo || "").toLowerCase() !== "macho"
+    (v) => v.status === 2
   );
 
   const titulos = [

--- a/src/utils/apiFuncoes.js
+++ b/src/utils/apiFuncoes.js
@@ -226,6 +226,27 @@ export async function salvarFichaAnimalSQLite(numeroAnimal, dados) {
   return await atualizarItem("animais/ficha", numeroAnimal, dados);
 }
 
+// Chama o endpoint de secagem do backend
+export async function aplicarSecagem(idAnimal, dataSecagem, plano) {
+  return await fetchJson(`${BASE_URL}/animais/${idAnimal}/secagem`, {
+    method: 'POST',
+    body: JSON.stringify({ dataSecagem, plano }),
+  });
+}
+
+// Chama o endpoint de parto do backend
+export async function registrarParto(idAnimal, dataParto, sexoBezerro) {
+  return await fetchJson(`${BASE_URL}/animais/${idAnimal}/parto`, {
+    method: 'POST',
+    body: JSON.stringify({ dataParto, sexoBezerro }),
+  });
+}
+
+// Busca eventos (linha do tempo) de um animal
+export async function buscarEventosAnimal(idAnimal) {
+  return await fetchJson(`${BASE_URL}/eventos/${idAnimal}`);
+}
+
 // ==== EXCLUSÕES ====
 
 export async function deletarItem(rota, id) {

--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -1,0 +1,14 @@
+// Funções utilitárias para lidar com datas no formato DD/MM/AAAA
+export function parseBRDate(dataStr) {
+  if (!dataStr) return null;
+  const [dia, mes, ano] = dataStr.split('/');
+  return new Date(ano, mes - 1, dia);
+}
+
+export function diffDias(data) {
+  if (!data) return null;
+  const hoje = new Date();
+  const d1 = new Date(data.getFullYear(), data.getMonth(), data.getDate());
+  const d2 = new Date(hoje.getFullYear(), hoje.getMonth(), hoje.getDate());
+  return Math.ceil((d1 - d2) / (1000 * 60 * 60 * 24));
+}


### PR DESCRIPTION
## Summary
- cria util `dateUtils` para lidar com datas e diferenças de dias
- ajusta filtros nos componentes de Pré-parto, Parto e Secagem
- adiciona chamadas de API para registrar parto, secagem e listar eventos

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68880b0170588328ba784adba36c5f56