### PR TITLE
Integrar ações de parto e secagem

### DIFF
--- a/src/pages/Animais/ConteudoParto.jsx
+++ b/src/pages/Animais/ConteudoParto.jsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
-import AcaoParto from './AcaoParto';
+import ModalRegistrarParto from './ModalRegistrarParto';
 import '../../styles/botoes.css';
 import '../../styles/tabelaModerna.css';
 import { parseBRDate, diffDias } from '@/utils/dateUtils';
+import { buscarAnimais } from '../../utils/apiFuncoes';
+import { toast } from 'react-toastify';
 
-export default function ConteudoParto({ vacas = [] }) {
+export default function ConteudoParto({ vacas = [], onAtualizar }) {
   const [colunasVisiveis, setColunasVisiveis] = useState({
     numero: true, brinco: true, lactacoes: true, del: true,
     categoria: true, idade: true, ultimaIA: true, ultimoParto: true,
@@ -132,9 +134,18 @@ export default function ConteudoParto({ vacas = [] }) {
       </table>
 
       {mostrarModalParto && vacaSelecionada && (
-        <AcaoParto
-          vaca={vacaSelecionada}
-          onFechar={() => setMostrarModalParto(false)}
+        <ModalRegistrarParto
+          animal={vacaSelecionada}
+          onClose={() => setMostrarModalParto(false)}
+          onRegistrado={async () => {
+            try {
+              const lista = await buscarAnimais();
+              onAtualizar && onAtualizar(lista);
+            } catch (err) {
+              console.error('Erro ao atualizar lista de animais:', err);
+              toast.error('Erro ao atualizar lista de animais');
+            }
+          }}
         />
       )}
     </div>

--- a/src/pages/Animais/ConteudoSecagem.jsx
+++ b/src/pages/Animais/ConteudoSecagem.jsx
@@ -3,6 +3,8 @@ import React, { useState } from 'react';
 import AcaoSecagem from './AcaoSecagem';
 import '../../styles/tabelaModerna.css';
 import '../../styles/botoes.css';
+import { buscarAnimais } from '../../utils/apiFuncoes';
+import { toast } from 'react-toastify';
 
 function calcularPrevisaoParto(dataIA) {
   if (!dataIA || dataIA.length !== 10) return null;
@@ -12,7 +14,7 @@ function calcularPrevisaoParto(dataIA) {
   return data.toLocaleDateString('pt-BR');
 }
 
-export default function ConteudoSecagem({ vacas }) {
+export default function ConteudoSecagem({ vacas, onAtualizar }) {
   const [colunasVisiveis, setColunasVisiveis] = useState({
     numero: true,
     brinco: true,
@@ -43,9 +45,15 @@ export default function ConteudoSecagem({ vacas }) {
     setMostrarModalSecagem(true);
   };
 
-  const aplicarSecagem = (dados) => {
-    console.log("✅ Secagem aplicada:", dados);
+  const aplicarSecagem = async () => {
     setMostrarModalSecagem(false);
+    try {
+      const lista = await buscarAnimais();
+      onAtualizar && onAtualizar(lista);
+    } catch (err) {
+      console.error('Erro ao atualizar lista de animais:', err);
+      toast.error('Erro ao atualizar lista de animais');
+    }
   };
 
   const vacasFiltradas = (Array.isArray(vacas) ? vacas : []).filter(

--- a/src/pages/Animais/ConteudoTodosAnimais.jsx
+++ b/src/pages/Animais/ConteudoTodosAnimais.jsx
@@ -14,11 +14,11 @@ export default function ConteudoTodosAnimais({ vacas, onAtualizar }) {
       case 'plantel':
         return <ConteudoPlantel vacas={vacas} onAtualizar={onAtualizar} />;
       case 'secagem':
-        return <ConteudoSecagem vacas={vacas} />;
+        return <ConteudoSecagem vacas={vacas} onAtualizar={onAtualizar} />;
       case 'pre-parto':
         return <ConteudoPreParto vacas={vacas} />;
       case 'parto':
-        return <ConteudoParto vacas={vacas} />;
+        return <ConteudoParto vacas={vacas} onAtualizar={onAtualizar} />;
       default:
         return null;
     }

--- a/src/pages/Animais/FichaAnimalEventos.jsx
+++ b/src/pages/Animais/FichaAnimalEventos.jsx
@@ -1,36 +1,23 @@
-import React from "react";
+import React from 'react';
 
-export default function FichaAnimalEventos({ animal }) {
-  const eventos = Array.isArray(animal?.historico?.ocorrencias)
-    ? animal.historico.ocorrencias
-    : Array.isArray(animal.eventos)
-    ? animal.eventos
-    : [];
-  const tratamentos = Array.isArray(animal?.historico?.tratamentos)
-    ? animal.historico.tratamentos
-    : Array.isArray(animal.tratamentos)
-    ? animal.tratamentos
-    : [];
-
-  if (eventos.length === 0 && tratamentos.length === 0) {
+export default function FichaAnimalEventos({ eventos = [] }) {
+  if (!Array.isArray(eventos) || eventos.length === 0) {
     return (
-      <p style={{ fontStyle: "italic", color: "#777" }}>
-        Sem eventos ou tratamentos registrados.
+      <p style={{ fontStyle: 'italic', color: '#777' }}>
+        Sem eventos registrados.
       </p>
     );
   }
 
   return (
     <>
-      {eventos.map((e, i) => (
-        <p key={`e-${i}`}>
-          📍 <strong>{e.data}</strong> - {e.tipo}: {e.descricao}
-        </p>
-      ))}
-      {tratamentos.map((t, i) => (
-        <p key={`t-${i}`}>
-          💊 <strong>{t.data}</strong> - {t.nome} ({t.principioAtivo})
-        </p>
+      {eventos.map((ev) => (
+        <div key={ev.id} className="evento-item">
+          <strong>
+            {ev.dataEvento} — {ev.tipoEvento}
+          </strong>
+          <p>{ev.descricao}</p>
+        </div>
       ))}
     </>
   );

--- a/src/pages/Animais/ModalHistoricoCompleto.jsx
+++ b/src/pages/Animais/ModalHistoricoCompleto.jsx
@@ -3,7 +3,7 @@ import FichaAnimalLeite from './FichaAnimalLeite';
 import FichaAnimalPesagens from './FichaAnimalPesagens';
 import FichaAnimalEventos from './FichaAnimalEventos';
 import FichaAnimalReproducao from './FichaAnimalReproducao';
-import { buscarColecaoGenericaSQLite } from '../../utils/apiFuncoes.js';
+import { buscarColecaoGenericaSQLite, buscarEventosAnimal } from '../../utils/apiFuncoes.js';
 import { carregarRegistroFirestore } from '../../utils/registroReproducao';
 
 export default function ModalHistoricoCompleto({ animal, onClose }) {
@@ -17,6 +17,7 @@ export default function ModalHistoricoCompleto({ animal, onClose }) {
   const [diagnosticos, setDiagnosticos] = useState([]);
   const [partos, setPartos] = useState([]);
   const [secagens, setSecagens] = useState([]);
+  const [eventos, setEventos] = useState([]);
   const [abaAtiva, setAbaAtiva] = useState('reproducao');
 
   function calcularDias(dataInicio, dataFim) {
@@ -81,9 +82,18 @@ export default function ModalHistoricoCompleto({ animal, onClose }) {
 
       setProducaoLeite(listaLeite);
       setLactacoes(grupos);
-      setLactacaoSelecionada(0);
-    })();
+    setLactacaoSelecionada(0);
+  })();
   }, [animal]);
+
+  useEffect(() => {
+    async function carregarEventos() {
+      if (!animal?.id) return;
+      const lista = await buscarEventosAnimal(animal.id);
+      setEventos(Array.isArray(lista) ? lista : []);
+    }
+    carregarEventos();
+  }, [animal.id]);
 
   useEffect(() => {
     const escFunction = (e) => {
@@ -148,7 +158,7 @@ export default function ModalHistoricoCompleto({ animal, onClose }) {
             <FichaAnimalPesagens animal={animal} pesagens={pesagens} />
           )}
           {abaAtiva === 'eventos' && (
-            <FichaAnimalEventos animal={animal} ocorrencias={ocorrencias} tratamentos={tratamentos} />
+            <FichaAnimalEventos eventos={eventos} />
           )}
           {abaAtiva === 'reproducao' && (
             <FichaAnimalReproducao

--- a/src/pages/Animais/ModalRegistrarParto.jsx
+++ b/src/pages/Animais/ModalRegistrarParto.jsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react';
+import { registrarParto } from '../../utils/apiFuncoes';
+import { toast } from 'react-toastify';
+import '../../styles/botoes.css';
+
+export default function ModalRegistrarParto({ animal, onClose, onRegistrado }) {
+  const [dataParto, setDataParto] = useState('');
+  const [sexo, setSexo] = useState('femea');
+
+  useEffect(() => {
+    const esc = e => e.key === 'Escape' && onClose();
+    window.addEventListener('keydown', esc);
+    return () => window.removeEventListener('keydown', esc);
+  }, [onClose]);
+
+  const salvar = async () => {
+    try {
+      await registrarParto(animal.id, dataParto, sexo);
+      toast.success('Parto registrado com sucesso');
+      onRegistrado && onRegistrado();
+      onClose();
+    } catch (err) {
+      console.error('Erro ao registrar parto:', err);
+      toast.error('Erro ao registrar parto');
+    }
+  };
+
+  return (
+    <div style={overlay}>
+      <div style={modal}>
+        <h3 style={{ marginBottom: '1rem' }}>🐄 Registrar Parto — {animal.numero}</h3>
+        <div className="flex flex-col gap-3">
+          <label>Data do Parto</label>
+          <input
+            type="date"
+            value={dataParto}
+            onChange={e => setDataParto(e.target.value)}
+            className="border rounded p-2"
+          />
+          <label>Sexo do Bezerro</label>
+          <select
+            value={sexo}
+            onChange={e => setSexo(e.target.value)}
+            className="border rounded p-2"
+          >
+            <option value="femea">Fêmea</option>
+            <option value="macho">Macho</option>
+          </select>
+          <div className="flex justify-end gap-2 pt-2">
+            <button onClick={onClose} className="botao-cancelar pequeno">Cancelar</button>
+            <button onClick={salvar} className="botao-acao pequeno">Salvar</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const overlay = {
+  position: 'fixed',
+  inset: 0,
+  backgroundColor: 'rgba(0,0,0,0.6)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  zIndex: 9999,
+};
+
+const modal = {
+  background: '#fff',
+  padding: '1.5rem',
+  borderRadius: '1rem',
+  width: '320px',
+  fontFamily: 'Poppins, sans-serif',
+};


### PR DESCRIPTION
## Summary
- add simple modal to register a parto via API
- call backend endpoints when registering secagem
- refresh lists after parto ou secagem
- fetch animal event timeline from backend
- display events in FichaAnimalEventos

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68882b1523988328be9f7ea441f8245b