### PR TITLE
Integrate reproduction with tasks and inventory

### DIFF
--- a/backend/routes/reproducaoRoutes.js
+++ b/backend/routes/reproducaoRoutes.js
@@ -3,6 +3,8 @@ const router = express.Router();
 const Reproducao = require('../models/reproducaoModel');
 const { initDB } = require('../db');
 const autenticarToken = require('../middleware/autenticarToken');
+// Importa o serviço que integra reprodução com tarefas e estoque
+const { handleReproducao } = require('../services/reproducaoService');
 
 router.use(autenticarToken);
 
@@ -15,12 +17,16 @@ router.get('/:numero', (req, res) => {
 router.post('/', (req, res) => {
   const db = initDB(req.user.email);
   const dados = Reproducao.registrarIA(db, req.body, req.user.idProdutor);
+  // Aciona serviços complementares (tarefas, estoque, etc.)
+  handleReproducao(db, req.body, req.user.idProdutor);
   res.status(201).json(dados);
 });
 
 router.post('/diagnostico', (req, res) => {
   const db = initDB(req.user.email);
   const dados = Reproducao.registrarDiagnostico(db, req.body, req.user.idProdutor);
+  // Diagnóstico também aciona o serviço de reprodução
+  handleReproducao(db, req.body, req.user.idProdutor);
   res.status(201).json(dados);
 });
 

--- a/backend/services/reproducaoService.js
+++ b/backend/services/reproducaoService.js
@@ -1,0 +1,45 @@
+const Tarefas = require('../models/tarefasModel');
+const Estoque = require('../models/estoqueModel');
+/**
+ * Serviço responsável por acionar outras funcionalidades (tarefas, estoque, etc.)
+ * quando uma inseminação ou diagnóstico reprodutivo é registrado.
+ * Exemplo: agenda uma tarefa de checagem futura e deduz itens do estoque.
+ */
+function handleReproducao(db, dados, idProdutor) {
+  // Agenda uma tarefa de checar gestação 30 dias após a data informada
+  if (dados.data) {
+    const checkDate = new Date(dados.data);
+    checkDate.setDate(checkDate.getDate() + 30);
+    Tarefas.create(
+      db,
+      {
+        descricao: `Checar gestação do animal ${dados.numero}`,
+        data: checkDate.toISOString().slice(0, 10),
+        concluida: false,
+      },
+      idProdutor,
+    );
+  }
+  // Deduz do estoque os itens utilizados no protocolo (se fornecidos)
+  if (Array.isArray(dados.itensUsados)) {
+    dados.itensUsados.forEach((itemUso) => {
+      const current = Estoque.getById(db, itemUso.idItem, idProdutor);
+      if (current) {
+        const novaQtd = current.quantidade - itemUso.quantidade;
+        Estoque.update(
+          db,
+          current.id,
+          {
+            item: current.item,
+            quantidade: novaQtd < 0 ? 0 : novaQtd,
+            unidade: current.unidade,
+          },
+          idProdutor,
+        );
+      }
+    });
+  }
+}
+
+module.exports = { handleReproducao };
+


### PR DESCRIPTION
## Summary
- add a service to schedule follow-up tasks and deduct used items
- invoke the service from reproduction routes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688898d1fbbc832881276bcec2bb699b