### PR TITLE
Fix input mask import

### DIFF
--- a/src/pages/Auth/Cadastro.jsx
+++ b/src/pages/Auth/Cadastro.jsx
@@ -1,6 +1,9 @@
 import { useState, useEffect } from 'react';
 import Select from 'react-select';
-import InputMask from 'react-input-mask@2.0.4';
+// Importa o componente de máscara de entrada sem especificar a versão.
+// A versão correta é definida em package.json (react-input-mask ^3.0.0),
+// e o Rollup/Vite não consegue resolver imports com “@versão” na string.
+import InputMask from 'react-input-mask';
 import { Eye, EyeOff } from 'lucide-react';
 import { useNavigate, useSearchParams, Link } from 'react-router-dom';
 import api from '../../api';


### PR DESCRIPTION
## Summary
- fix import of `react-input-mask` in Cadastro.jsx and add explanatory comment

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688941e42e108328a28aeaa20c04af04