### PR TITLE
Fix axios base URL trailing slash

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -1,7 +1,9 @@
 import axios from 'axios';
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || '/api'
+  // Garante que a base da API termine com barra caso VITE_API_URL não esteja definida.
+  // Assim, chamadas como `api.post('auth/login')` resultam em '/api/auth/login' em vez de 'apiauth/login'.
+  baseURL: import.meta.env.VITE_API_URL ? import.meta.env.VITE_API_URL : '/api/',
 });
 
 api.interceptors.request.use((config) => {


### PR DESCRIPTION
## Summary
- ensure axios baseURL ends with trailing slash when `VITE_API_URL` is absent

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68894e96acdc83288a875e2e19ecee98