### PR TITLE
Add prenatal scheduling in reproduction service

### DIFF
--- a/backend/services/reproducaoService.js
+++ b/backend/services/reproducaoService.js
@@ -1,5 +1,6 @@
 const Tarefas = require('../models/tarefasModel');
 const Estoque = require('../models/estoqueModel');
+const Animais = require('../models/animaisModel');
 /**
  * Serviço responsável por acionar outras funcionalidades (tarefas, estoque, etc.)
  * quando uma inseminação ou diagnóstico reprodutivo é registrado.
@@ -38,6 +39,82 @@ function handleReproducao(db, dados, idProdutor) {
         );
       }
     });
+  }
+
+  // Se número do animal e data da IA forem fornecidos, agenda as tarefas de secagem e pré‑parto
+  if (dados.numero && dados.data) {
+    schedulePrenatalTasks(db, dados.numero, dados.data, idProdutor);
+  }
+}
+
+/**
+ * Agenda tarefas para secagem, pré‑parto e parto com base na data da inseminação.
+ * - Calcula a data prevista de parto (~283 dias de gestação).
+ * - Agenda secagem 60 dias antes, pré‑parto 14 dias antes e a preparação para parto 7 dias antes.
+ * - Atualiza a propriedade previsaoParto do animal, se existir, para facilitar consultas.
+ */
+function schedulePrenatalTasks(db, numeroAnimal, dataIA, idProdutor) {
+  try {
+    const iaDate = new Date(dataIA);
+    // 283 dias de gestação para bovinos leiteiros
+    const dueDate = new Date(iaDate);
+    dueDate.setDate(dueDate.getDate() + 283);
+
+    // Secagem 60 dias antes do parto
+    const dryingDate = new Date(dueDate);
+    dryingDate.setDate(dryingDate.getDate() - 60);
+    Tarefas.create(
+      db,
+      {
+        descricao: `Secar vaca ${numeroAnimal}`,
+        data: dryingDate.toISOString().slice(0, 10),
+        concluida: false,
+      },
+      idProdutor,
+    );
+
+    // Pré‑parto 14 dias antes do parto
+    const prePartoDate = new Date(dueDate);
+    prePartoDate.setDate(prePartoDate.getDate() - 14);
+    Tarefas.create(
+      db,
+      {
+        descricao: `Pré‑parto da vaca ${numeroAnimal}`,
+        data: prePartoDate.toISOString().slice(0, 10),
+        concluida: false,
+      },
+      idProdutor,
+    );
+
+    // Preparação para parto 7 dias antes do parto
+    const partoPrepDate = new Date(dueDate);
+    partoPrepDate.setDate(partoPrepDate.getDate() - 7);
+    Tarefas.create(
+      db,
+      {
+        descricao: `Próximo parto da vaca ${numeroAnimal}`,
+        data: partoPrepDate.toISOString().slice(0, 10),
+        concluida: false,
+      },
+      idProdutor,
+    );
+
+    // Atualiza a previsão de parto no cadastro do animal
+    const animal = Animais.getByNumero(db, numeroAnimal, idProdutor);
+    if (animal) {
+      Animais.update(
+        db,
+        animal.id,
+        {
+          ...animal,
+          previsaoParto: dueDate.toISOString().slice(0, 10),
+        },
+        idProdutor,
+      );
+    }
+  } catch (err) {
+    // Em caso de erro, registra no console sem interromper o fluxo
+    console.error('Erro ao agendar tarefas de pré‑parto:', err);
   }
 }
 


### PR DESCRIPTION
## Summary
- schedule prenatal tasks from reproduction actions
- update animal's expected birth date automatically

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68895a04c03083288806409b7646a6b7