### PR TITLE
Fix animal list defaults when no ficha complementar

### DIFF
--- a/backend/controllers/animaisController.js
+++ b/backend/controllers/animaisController.js
@@ -37,6 +37,10 @@ async function listarAnimais(req, res) {
           a.del = del;
         }
       }
+      // Garantir valores válidos caso o animal não possua ficha complementar
+      a.ultimaIA = a.ultimaIA || null;
+      a.ultimoParto = a.ultimoParto || null;
+      a.nLactacoes = a.nLactacoes ?? 0;
     }
     console.log('✅ Resultado:', animais);
     res.json(animais);


### PR DESCRIPTION
## Summary
- ensure animals without complementary records have valid fields

## Testing
- `npm run` *(shows available scripts)*

------
https://chatgpt.com/codex/tasks/task_e_688bfda4f42483288373c18f8cb370c6