### PR TITLE
Fix API permissions for non-admin users

### DIFF
--- a/backend/middleware/autenticarToken.js
+++ b/backend/middleware/autenticarToken.js
@@ -26,7 +26,15 @@ function autenticarToken(req, res, next) {
       )
       .get(decoded.idProdutor);
 
-    if (!usuario) return res.status(401).json({ message: 'Usuário não encontrado' });
+    if (!usuario) {
+      return res.status(401).json({ message: 'Usuário não encontrado' });
+    }
+
+    if (!decoded || !decoded.idProdutor) {
+      return res.status(403).json({
+        message: 'Usuário sem permissão ou produtor não identificado',
+      });
+    }
 
     const isAdmin = usuario.tipoConta === 'admin';
 

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -6,7 +6,14 @@ module.exports = function authMiddleware(req, res, next) {
   try {
     req.usuario = jwt.verify(token, process.env.JWT_SECRET);
     req.user = req.usuario;
-    console.log("\ud83d\udd10 Token decodificado no backend:", req.usuario);
+
+    if (!req.usuario || !req.usuario.idProdutor) {
+      return res
+        .status(403)
+        .json({ erro: 'Usuário sem permissão ou produtor não identificado' });
+    }
+
+    console.log('🔑 Token decodificado no backend:', req.usuario);
     next();
   } catch {
     return res.status(403).json({ erro: 'Token inválido' });


### PR DESCRIPTION
## Summary
- enforce producer presence in `authMiddleware` and `autenticarToken`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688d552c07a88328b1318b6d0bab58de