### PR TITLE
Fix token parsing in axios interceptor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 backend/*.sqlite
 backend/*.sqlite3
 
+backend/package-lock.json

--- a/src/api.js
+++ b/src/api.js
@@ -7,7 +7,13 @@ const api = axios.create({
 });
 
 api.interceptors.request.use((config) => {
-  const token = localStorage.getItem('token');
+  const stored = localStorage.getItem('token');
+  let token = null;
+  try {
+    token = stored ? JSON.parse(stored)?.token ?? stored : null;
+  } catch (err) {
+    token = stored;
+  }
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }


### PR DESCRIPTION
## Summary
- handle JSON-formatted tokens in `src/api.js`
- ignore backend `package-lock.json`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688d593f3fdc8328a6b9d7a226451730