### PR TITLE
Add proxy middleware for auth headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "react-toastify": "^11.0.5",
     "recharts": "^2.15.3",
     "sqlite3": "^5.1.7",
-    "xlsx": "^0.18.5"
+    "xlsx": "^0.18.5",
+    "http-proxy-middleware": "^2.0.6"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.11",

--- a/src/setupProxy.js
+++ b/src/setupProxy.js
@@ -1,0 +1,19 @@
+const { createProxyMiddleware } = require('http-proxy-middleware');
+
+module.exports = function (app) {
+  app.use(
+    '/api',
+    createProxyMiddleware({
+      target: 'http://localhost:8080',
+      changeOrigin: true,
+      pathRewrite: { '^/api': '/api' },
+      onProxyReq: (proxyReq, req) => {
+        // Encaminha o cabeçalho Authorization, se existir
+        if (req.headers['authorization']) {
+          proxyReq.setHeader('Authorization', req.headers['authorization']);
+        }
+      },
+    }),
+  );
+};
+


### PR DESCRIPTION
## Summary
- proxy API requests through `src/setupProxy.js`
- declare `http-proxy-middleware` dependency

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d5ba30c948328ba176ea6f84e7359