### PR TITLE
Fix JWT validation and invalid token auto-login

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,0 +1,1 @@
+JWT_SECRET=segredo-super-seguro

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -5,23 +5,15 @@ module.exports = function authMiddleware(req, res, next) {
   if (!token) return res.status(401).json({ erro: 'Token ausente' });
 
   try {
-    req.usuario = jwt.verify(token, process.env.JWT_SECRET);
-    req.user = req.usuario;
-
-    // ✅ Verificação mais clara e com logs
-    if (!req.usuario) {
-      console.log('❌ Token inválido ou ausente');
-      return res.status(403).json({ erro: 'Token inválido' });
-    }
+    const decoded = jwt.verify(token, process.env.JWT_SECRET);
+    req.usuario = decoded;
+    req.user = decoded;
 
     if (!req.usuario.idProdutor) {
-      console.log('❌ idProdutor ausente no token:', req.usuario);
-      return res
-        .status(403)
-        .json({ erro: 'Usuário sem permissão: idProdutor ausente' });
+      console.log('❌ idProdutor ausente no token');
+      return res.status(403).json({ erro: 'Permissão negada: produtor não identificado' });
     }
 
-    console.log('🔓 Token válido. Usuário autenticado:', req.usuario);
     next();
   } catch (e) {
     console.error('❌ Erro ao verificar token:', e.message);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,8 +4,23 @@ import Login from './pages/Auth/Login';
 import Inicio from './pages/Inicio'; // substitua pelo seu componente correto
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
+import jwtDecode from 'jwt-decode';
 
 export default function App() {
+  const token = localStorage.getItem('token');
+  if (token) {
+    try {
+      const decoded = jwtDecode(token);
+      if (!decoded || !decoded.idProdutor) {
+        localStorage.removeItem('token');
+        window.location.href = '/login';
+      }
+    } catch (e) {
+      localStorage.removeItem('token');
+      window.location.href = '/login';
+    }
+  }
+
   return (
     <BrowserRouter>
       <Routes>


### PR DESCRIPTION
## Summary
- improve backend JWT authentication middleware to verify token and require idProdutor
- add backend JWT secret configuration
- validate token on app load to prevent automatic login with invalid credentials

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688eb05984e083288fe0fef7e8390977