### PR TITLE
fix: validate token on app load

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,39 +1,47 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, useNavigate } from 'react-router-dom';
+import { useEffect } from 'react';
 import SistemaBase from './layout/SistemaBase';
 import Login from './pages/Auth/Login';
 import Inicio from './pages/Inicio'; // substitua pelo seu componente correto
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 import jwtDecode from 'jwt-decode';
+function AppRoutes() {
+  const navigate = useNavigate();
 
-export default function App() {
-  const token = localStorage.getItem('token');
-  if (token) {
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (!token) return;
     try {
       const decoded = jwtDecode(token);
       if (!decoded || !decoded.idProdutor) {
         localStorage.removeItem('token');
-        window.location.href = '/login';
+        navigate('/login');
       }
     } catch (e) {
       localStorage.removeItem('token');
-      window.location.href = '/login';
+      navigate('/login');
     }
-  }
+  }, [navigate]);
 
   return (
+    <Routes>
+      {/* Login fora do layout principal */}
+      <Route path="/login" element={<Login />} />
+
+      {/* Todo o resto usa o layout SistemaBase */}
+      <Route path="/" element={<SistemaBase />}>
+        <Route path="inicio" element={<Inicio />} />
+        {/* Aqui você pode adicionar outras páginas depois */}
+      </Route>
+    </Routes>
+  );
+}
+
+export default function App() {
+  return (
     <BrowserRouter>
-      <Routes>
-        {/* Login fora do layout principal */}
-        <Route path="/login" element={<Login />} />
-
-        {/* Todo o resto usa o layout SistemaBase */}
-        <Route path="/" element={<SistemaBase />}>
-          <Route path="inicio" element={<Inicio />} />
-          {/* Aqui você pode adicionar outras páginas depois */}
-        </Route>
-      </Routes>
-
+      <AppRoutes />
       <ToastContainer position="bottom-right" autoClose={3000} hideProgressBar={false} pauseOnHover theme="light" />
     </BrowserRouter>
   );


### PR DESCRIPTION
## Summary
- add client-side token validation and redirect on bad tokens

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688fda680e008328be6b6ebe891c8c01