### PR TITLE
feat: Fase 2 — Backend unificado + API estável + remoção de sqlite do front

### DIFF
--- a/backend/services/animalsService.js
+++ b/backend/services/animalsService.js
@@ -1,0 +1,30 @@
+const db = require('./dbAdapter');
+const animaisModel = require('../models/animaisModel');
+
+function list(idProdutor) {
+  return animaisModel.getAll(db.getDb(), idProdutor);
+}
+
+function getById(id, idProdutor) {
+  return animaisModel.getById(db.getDb(), id, idProdutor);
+}
+
+function create(animal, idProdutor) {
+  return animaisModel.create(db.getDb(), animal, idProdutor);
+}
+
+function update(id, animal, idProdutor) {
+  return animaisModel.update(db.getDb(), id, animal, idProdutor);
+}
+
+function remove(id, idProdutor) {
+  return animaisModel.remove(db.getDb(), id, idProdutor);
+}
+
+module.exports = {
+  list,
+  getById,
+  create,
+  update,
+  remove,
+};

--- a/backend/services/dbAdapter.js
+++ b/backend/services/dbAdapter.js
@@ -1,0 +1,25 @@
+const { initDB, getDb } = require('../db');
+
+function query(sql, params = []) {
+  const db = getDb();
+  return db.prepare(sql).all(params);
+}
+
+function run(sql, params = []) {
+  const db = getDb();
+  return db.prepare(sql).run(params);
+}
+
+function transaction(cb) {
+  const db = getDb();
+  const trx = db.transaction(cb);
+  return trx();
+}
+
+module.exports = {
+  initDB,
+  query,
+  run,
+  transaction,
+  getDb,
+};

--- a/backend/services/eventsService.js
+++ b/backend/services/eventsService.js
@@ -1,0 +1,10 @@
+// Placeholder service for health events
+function registrarOcorrencia() {}
+function registrarTratamento() {}
+function listarHistorico() { return []; }
+
+module.exports = {
+  registrarOcorrencia,
+  registrarTratamento,
+  listarHistorico,
+};

--- a/backend/services/reproductionService.js
+++ b/backend/services/reproductionService.js
@@ -1,0 +1,14 @@
+// Placeholder service for reproductive events
+function registrarInseminacao() {}
+function registrarDiagnostico() {}
+function registrarParto() {}
+function registrarSecagem() {}
+function listarHistorico() { return []; }
+
+module.exports = {
+  registrarInseminacao,
+  registrarDiagnostico,
+  registrarParto,
+  registrarSecagem,
+  listarHistorico,
+};

--- a/docs/reorg-fase2-relatorio.md
+++ b/docs/reorg-fase2-relatorio.md
@@ -1,0 +1,6 @@
+# Reorg Fase 2 – Relatório
+
+## Serviços iniciais
+- Criado `backend/services/dbAdapter.js` para padronizar acesso ao banco.
+- Criado `backend/services/animalsService.js` com operações básicas.
+- Stubs iniciais para `reproductionService` e `eventsService`.


### PR DESCRIPTION
## Summary
- add database adapter and initial service layer for animals, reproduction and events
- document start of phase 2 reorganization

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_6897cc4b387883289eec990bf1dc1f44