### PR TITLE
fix: derivados de animais e limpeza de sqlite no front (Fase 2.1.1)

### DIFF
--- a/backend/services/animalsService.js
+++ b/backend/services/animalsService.js
@@ -26,7 +26,7 @@ function addDerived(animal) {
 }
 
 function list(idProdutor) {
-  const animais = animaisModel.getAll(db.getDb(), idProdutor);
+  const animais = animaisModel.getAll(db.getDb(), idProdutor) || [];
   return animais.map(addDerived);
 }
 


### PR DESCRIPTION
## Summary
- garantido mapeamento de campos derivados ao listar animais
- verificação de ausências de imports residuais de `src/sqlite`

## Testing
- `curl -v -X POST http://localhost:3000/api/v1/animais -H "Content-Type: application/json" -d '{"numero":1,"brinco":"A1","nascimento":"2024-01-01"}'`
- `curl -s http://localhost:3000/api/v1/animais`
- `curl -s -X POST http://localhost:3000/api/v1/reproducao/1/inseminacoes -H "Content-Type: application/json" -d '{"data":"2024-02-01"}'`
- `curl -s http://localhost:3000/api/v1/reproducao/1/historico`


------
https://chatgpt.com/codex/tasks/task_e_6897fbc8611483288aa7047c3f5712e6