### PR TITLE
chore: Fase 2.3.2 — Colapso de EscolherPlano para Unified

### DIFF
--- a/docs/reorg-fase2.3-relatorio.md
+++ b/docs/reorg-fase2.3-relatorio.md
@@ -24,6 +24,17 @@
     `GraficoDescarteIdade.jsx`, `ResumoLactacoes.jsx`, `icones/informacoes.png`.
 - Varredura com `rg` confirmou ausência de imports externos antes da exclusão.
 
+## Colapso EscolherPlano
+- Arquivos removidos:
+  - `src/usuario/auth/EscolherPlano.jsx`
+  - `src/usuario/auth/EscolherPlanoCadastro.jsx`
+  - `src/usuario/auth/EscolherPlanoUsuario.jsx`
+  - `src/usuario/auth/EscolherPlanoInicio.jsx`
+- Rotas/locais atualizados para `EscolherPlanoUnified`:
+  - `/escolher-plano` → `mode="inicio"`
+  - `/escolher-plano-finalizar` → `mode="cadastro"`
+- Build: tentativa de `npm install` falhou (`react-input-mask@^3.0.0` ausente), portanto `npm run build` não pôde ser executado.
+
 ## Checklist – Próximo passo (Fase 2.4)
 - [ ] Ativar cron via `ENABLE_PREPARTO_JOB=true` (opcional).
 - [ ] Iniciar testes ponta a ponta no front.

--- a/src/usuario/auth/EscolherPlano.jsx
+++ b/src/usuario/auth/EscolherPlano.jsx
@@ -1,5 +1,0 @@
-import EscolherPlanoUnified from './EscolherPlanoUnified';
-
-export default function EscolherPlano(props) {
-  return <EscolherPlanoUnified mode="usuario" admin {...props} />;
-}

--- a/src/usuario/auth/EscolherPlanoCadastro.jsx
+++ b/src/usuario/auth/EscolherPlanoCadastro.jsx
@@ -1,5 +1,0 @@
-import EscolherPlanoUnified from './EscolherPlanoUnified';
-
-export default function EscolherPlanoCadastro(props) {
-  return <EscolherPlanoUnified mode="cadastro" {...props} />;
-}

--- a/src/usuario/auth/EscolherPlanoInicio.jsx
+++ b/src/usuario/auth/EscolherPlanoInicio.jsx
@@ -1,5 +1,0 @@
-import EscolherPlanoUnified from './EscolherPlanoUnified';
-
-export default function EscolherPlanoInicio(props) {
-  return <EscolherPlanoUnified mode="inicio" {...props} />;
-}

--- a/src/usuario/auth/EscolherPlanoUsuario.jsx
+++ b/src/usuario/auth/EscolherPlanoUsuario.jsx
@@ -1,5 +1,0 @@
-import EscolherPlanoUnified from './EscolherPlanoUnified';
-
-export default function EscolherPlanoUsuario(props) {
-  return <EscolherPlanoUnified mode="usuario" {...props} />;
-}


### PR DESCRIPTION
## Summary
- remove wrappers de EscolherPlano, consolidando uso apenas de EscolherPlanoUnified
- documenta colapso do componente e estado da build

## Testing
- `npm install` *(falhou: No matching version found for react-input-mask@^3.0.0)*
- `npm run build` *(falhou: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898d7e0302083289994ed0a02f4cdd4