### PR TITLE
fix: alinhar dependências e configuração de build

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,14 @@
-VITE_API_URL=http://localhost:3000/api
+# Frontend
+VITE_API_URL=http://localhost:3000
 
-# SMTP (preencher se necessário)
-# EMAIL_REMETENTE=
-# EMAIL_SENHA_APP=
-# EMAIL_SERVICE=
+# Backend (email)
+SMTP_HOST=
+SMTP_PORT=
+SMTP_SECURE=false
+SMTP_USER=
+SMTP_PASS=
+MAIL_FROM="Gestão Leiteira <no-reply@example.com>"
 
-# Se quiser rodar automático (desativado por padrão)
-# ENABLE_PREPARTO_JOB=false
-# PREPARTO_WINDOW_DAYS=21
+# Jobs de pré-parto (opcional; por padrão desligado)
+ENABLE_PREPARTO_JOB=false
+PREPARTO_WINDOW_DAYS=21

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,9 +1,9 @@
+require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
 const dbMiddleware = require('./middleware/dbMiddleware');
 const path = require('path');
 const fs = require('fs');
-require('dotenv').config();
 
 const vacasRoutes = require('./routes/vacasRoutes');
 const animaisRoutes = require('./routes/animaisRoutes');

--- a/docs/smoke-fase2.4.1.md
+++ b/docs/smoke-fase2.4.1.md
@@ -1,0 +1,7 @@
+# Smoke Test Fase 2.4.1
+
+## Build
+`npm run build` falhou: `vite` não encontrado (dependências não instaladas; `npm install` retornou ENETUNREACH).
+
+## Passos manuais
+Não foi possível executar `npm run dev` devido à falta de dependências.

--- a/package.json
+++ b/package.json
@@ -4,12 +4,11 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "concurrently -k -n FRONT,BACK \"vite\" \"nodemon backend/server.js\"",
+    "dev:front": "vite",
+    "dev:back": "nodemon backend/server.js",
     "build": "vite build",
-    "preview": "vite preview",
-    "start-server": "nodemon backend/server.js",
-    "start-ngrok": "node startWithNgrok.js",
-    "start-tudo": "node start-tudo.js"
+    "preview": "vite preview"
   },
   "dependencies": {
     "@fullcalendar/bootstrap5": "^6.1.17",
@@ -25,7 +24,7 @@
     "chartjs-adapter-date-fns": "^3.0.0",
     "clsx": "^2.1.1",
     "cors": "^2.8.5",
-    "dotenv": "^17.0.1",
+    "dotenv": "^16.4.5",
     "express": "^4.21.2",
     "file-saver": "^2.0.5",
     "framer-motion": "^12.7.4",
@@ -55,12 +54,12 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.11",
-    "@vitejs/plugin-react": "^4.6.0",
+    "@vitejs/plugin-react": "^4.3.0",
     "autoprefixer": "^10.4.21",
-    "concurrently": "^9.2.0",
-    "nodemon": "^3.1.10",
+    "concurrently": "^8.2.2",
+    "nodemon": "^3.1.0",
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.11",
-    "vite": "^6.3.2"
+    "vite": "^5.3.0"
   }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,31 +1,27 @@
-// vite.config.js
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { fileURLToPath, URL } from 'node:url';
+
+const API_TARGET = process.env.VITE_API_URL || 'http://localhost:3000';
 
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
-    },
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
   },
   server: {
-    host: true,
     port: 5173,
-    strictPort: true,
-    allowedHosts: ['.ngrok-free.app'],
-    fs: {
-      strict: false,
-    },
+    proxy: {
+      '/api': {
+        target: API_TARGET,
+        changeOrigin: true,
+        secure: false
+      }
+    }
   },
-  // ✅ ESSA OPÇÃO FAZ O REACT ROUTER FUNCIONAR CORRETAMENTE COM REFRESH E NAVIGATE
   build: {
-    outDir: 'dist',
-  },
-  preview: {
-    // Permite que o preview do build funcione com SPA
-    // (caso use `vite preview` depois do build)
-    port: 4173,
-  },
+    outDir: 'dist'
+  }
 });


### PR DESCRIPTION
## Summary
- padronize scripts e dependências (vite, plugin-react, dotenv, concurrently, nodemon)
- configure Vite com proxy para `/api`
- carregue variáveis de ambiente no backend e atualize `.env.example`
- registrar smoke test da fase 2.4.1

## Testing
- `npm install` *(falhou: request to registry.npmjs.org ENETUNREACH)*
- `npm run build` *(falhou: vite não encontrado)*

------
https://chatgpt.com/codex/tasks/task_e_68991bc3d54883289e1ca99558c8200c