### PR TITLE
feat(auth): resend verification code + forgot/reset password

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,4 @@ SMTP_PASS=
 MAIL_FROM="Gestão Leiteira <no-reply@example.com>"
 ENABLE_PREPARTO_JOB=false
 PREPARTO_WINDOW_DAYS=21
+AUTH_BASE_URL=http://localhost:5173

--- a/backend/routes/authRoutes.js
+++ b/backend/routes/authRoutes.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const controller = require('../controllers/authController');
 const autenticar = require('../middleware/autenticarToken');
+const rateLimit = require('../middleware/rateLimit');
 
 
 // ✅ Cadastro: envia o código de verificação por e-mail
@@ -12,7 +13,9 @@ router.post('/register', controller.cadastro); // alias /auth/register
 // ✅ Verifica o código enviado por e-mail e cria o usuário
 router.post('/verificar-email', controller.verificarEmail);
 router.post('/verify-code', controller.verifyCode); // alias /auth/verify-code
-router.post('/forgot-password', controller.solicitarReset); // envia codigo de reset
+router.post('/send-code', rateLimit, controller.sendCode);
+router.post('/forgot-password', rateLimit, controller.forgotPassword);
+router.post('/reset-password', controller.resetPassword);
 router.post('/finalizar-cadastro', controller.finalizarCadastro);
 
 // ✅ Login (só funciona após verificação do e-mail)

--- a/backend/services/emailService.js
+++ b/backend/services/emailService.js
@@ -1,0 +1,38 @@
+const nodemailer = require('nodemailer');
+require('dotenv').config();
+
+const transporter = nodemailer.createTransport({
+  host: 'smtp.zoho.com',
+  port: 465,
+  secure: true,
+  auth: {
+    user: process.env.EMAIL_REMETENTE,
+    pass: process.env.EMAIL_SENHA_APP,
+  },
+});
+
+async function sendCode(to, code) {
+  const message = {
+    from: process.env.EMAIL_REMETENTE,
+    to,
+    subject: 'Código de verificação - Gestão Leiteira',
+    text: `Seu código de verificação é: ${code}`,
+    headers: { 'X-Mailer': 'GestaoLeiteira' },
+    replyTo: 'no-reply@gestaoleiteira.com',
+  };
+  return transporter.sendMail(message);
+}
+
+async function sendTemplate(to, subject, html) {
+  const message = {
+    from: process.env.EMAIL_REMETENTE,
+    to,
+    subject,
+    html,
+    headers: { 'X-Mailer': 'GestaoLeiteira' },
+    replyTo: 'no-reply@gestaoleiteira.com',
+  };
+  return transporter.sendMail(message);
+}
+
+module.exports = { sendCode, sendTemplate };

--- a/backend/services/tempTokens.js
+++ b/backend/services/tempTokens.js
@@ -1,0 +1,3 @@
+module.exports = {
+  resetTokens: new Map(),
+};

--- a/backend/services/userService.js
+++ b/backend/services/userService.js
@@ -1,0 +1,21 @@
+const { resetTokens } = require('./tempTokens');
+
+function setResetToken(email, userId, token, exp) {
+  resetTokens.set(token, { email, userId, exp });
+}
+
+function getResetToken(token) {
+  const data = resetTokens.get(token);
+  if (!data) return null;
+  if (Date.now() > data.exp) {
+    resetTokens.delete(token);
+    return null;
+  }
+  return data;
+}
+
+function deleteResetToken(token) {
+  resetTokens.delete(token);
+}
+
+module.exports = { setResetToken, getResetToken, deleteResetToken };

--- a/docs/reorg-fase2.7N-relatorio.md
+++ b/docs/reorg-fase2.7N-relatorio.md
@@ -1,0 +1,38 @@
+# Relatório Fase 2.7-N
+
+## Endpoints
+
+### POST /api/v1/auth/send-code
+- Payload:
+```json
+{ "email": "user@example.com" }
+```
+- Resposta:
+```json
+{ "ok": true, "sent": true }
+```
+
+### POST /api/v1/auth/forgot-password
+- Payload:
+```json
+{ "email": "user@example.com" }
+```
+- Resposta:
+```json
+{ "ok": true }
+```
+
+### POST /api/v1/auth/reset-password
+- Payload:
+```json
+{ "token": "<token>", "newPassword": "novaSenha" }
+```
+- Resposta:
+```json
+{ "ok": true }
+```
+
+## Considerações
+- `send-code` e `forgot-password` aplicam rate limit básico (5 requisições/60s por IP).
+- Tokens de reset são mantidos em memória por 30 minutos.
+- E-mails utilizam `emailService.sendTemplate`.


### PR DESCRIPTION
## Summary
- add resend verification code and password recovery endpoints
- store reset tokens in memory and expose email template helper
- document new auth flows and update env example

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a1c8bfc04832886854222c5775128