### PR TITLE
feat(auth): finalize resend/forgot/reset endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,4 +7,5 @@ SMTP_PASS=
 MAIL_FROM="Gestão Leiteira <no-reply@example.com>"
 ENABLE_PREPARTO_JOB=false
 PREPARTO_WINDOW_DAYS=21
+# Base URL used to build password reset links
 AUTH_BASE_URL=http://localhost:5173

--- a/backend/server.js
+++ b/backend/server.js
@@ -72,6 +72,7 @@ app.use('/api/touros', authMiddleware, dbMiddleware, tourosRoutes);
 app.use('/', mockRoutes);
 app.use('/api/auth', authRoutes);
 app.use('/api/v1/auth/send-code', rateLimit);
+app.use('/api/v1/auth/forgot-password', rateLimit);
 app.use('/api/v1/auth/login', rateLimit);
 app.use('/api/v1/auth', authRoutes);
 app.use('/api', rotasExtras);

--- a/docs/reorg-fase2.7N-relatorio.md
+++ b/docs/reorg-fase2.7N-relatorio.md
@@ -22,6 +22,8 @@
 { "ok": true }
 ```
 
+Gera um token temporário (30 min) e envia link de reset para `AUTH_BASE_URL`.
+
 ### POST /api/v1/auth/reset-password
 - Payload:
 ```json


### PR DESCRIPTION
## Summary
- apply rate limiter to `/api/v1/auth/forgot-password`
- document auth flows with example payloads and responses
- expose `AUTH_BASE_URL` in env example for reset links

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a354ef0188328800d884fb583e7b0