### PR TITLE
feat(front): amarrar estados/derivados e histórico ao backend

### DIFF
--- a/docs/reorg-fase2.8N-relatorio.md
+++ b/docs/reorg-fase2.8N-relatorio.md
@@ -3,6 +3,8 @@
 ## Telas ajustadas
 - **Animais/ConteudoPlantel**: usa `vaca.del`, `previsaoParto` e `previsaoSecagem` vindos do backend e exibe estado.
 - **Animais/ConteudoInativas**: busca animais inativos via API.
+- **Animais/ConteudoSecagem**: atualiza lista via `getAnimais({estado:'seca'})`.
+- **Animais/ConteudoParto**: recarrega com `getAnimais({estado:'lactante'})` após registrar parto.
 - **Animais/ModalHistoricoCompleto + FichaAnimalEventos**: seção "Histórico" carrega ocorrências de reprodução e saúde da API.
 - **Animais/FichaAnimalResumoReprodutivo**: apresenta DEL e previsões fornecidas pelo backend.
 - **Reproducao/VisaoGeralReproducao**: lista vacas conforme filtro de estado diretamente da API.

--- a/src/api.js
+++ b/src/api.js
@@ -119,6 +119,6 @@ export async function promoverPreParto() {
 }
 
 export async function ping() {
-  const res = await fetch('/api/v1/health');
-  return res.json();
+  const res = await api.get('v1/health');
+  return res.data;
 }

--- a/src/pages/Animais/ConteudoParto.jsx
+++ b/src/pages/Animais/ConteudoParto.jsx
@@ -3,7 +3,7 @@ import ModalRegistrarParto from './ModalRegistrarParto';
 import '../../styles/botoes.css';
 import '../../styles/tabelaModerna.css';
 import { parseBRDate, diffDias } from '@/utils/dateUtils';
-import { buscarAnimais } from '../../utils/apiFuncoes';
+import { getAnimais } from '../../api';
 import { toast } from 'react-toastify';
 
 export default function ConteudoParto({ vacas = [], onAtualizar }) {
@@ -139,7 +139,7 @@ export default function ConteudoParto({ vacas = [], onAtualizar }) {
           onClose={() => setMostrarModalParto(false)}
           onRegistrado={async () => {
             try {
-              const lista = await buscarAnimais();
+              const lista = await getAnimais({ estado: 'lactante' });
               onAtualizar && onAtualizar(lista);
             } catch (err) {
               console.error('Erro ao atualizar lista de animais:', err);

--- a/src/pages/Animais/ConteudoSecagem.jsx
+++ b/src/pages/Animais/ConteudoSecagem.jsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import AcaoSecagem from './AcaoSecagem';
 import '../../styles/tabelaModerna.css';
 import '../../styles/botoes.css';
-import { buscarAnimais } from '../../utils/apiFuncoes';
+import { getAnimais } from '../../api';
 import { toast } from 'react-toastify';
 
 export default function ConteudoSecagem({ vacas, onAtualizar }) {
@@ -40,7 +40,7 @@ export default function ConteudoSecagem({ vacas, onAtualizar }) {
   const aplicarSecagem = async () => {
     setMostrarModalSecagem(false);
     try {
-      const lista = await buscarAnimais();
+      const lista = await getAnimais({ estado: 'seca' });
       onAtualizar && onAtualizar(lista);
     } catch (err) {
       console.error('Erro ao atualizar lista de animais:', err);


### PR DESCRIPTION
## Summary
- fetch animal health endpoint through shared axios instance
- refresh Secagem list via `getAnimais({estado:'seca'})`
- refresh Parto list after registrations using `getAnimais({estado:'lactante'})`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a369e94a08328935944b03f6f5591