### PR TITLE
fix: remove bootstrap5 plugin to restore build

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "test": "node --test"
   },
   "dependencies": {
-    "@fullcalendar/bootstrap5": "6.1.11",
     "@fullcalendar/core": "6.1.11",
     "@fullcalendar/daygrid": "6.1.11",
     "@fullcalendar/interaction": "^6.1.17",

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -20,3 +20,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
     </ConfiguracaoProvider>
   </React.StrictMode>
 );
+// estilos FullCalendar
+import '@fullcalendar/common/main.css';
+import '@fullcalendar/daygrid/main.css';
+import '@fullcalendar/timegrid/main.css';


### PR DESCRIPTION
## Summary
- remove @fullcalendar/bootstrap5 dependency
- import FullCalendar styles directly

## Testing
- `npm test`
- `npm run build` *(fails: vite not found, due to install failing)*
- `npm i` *(fails: 403 Forbidden for @fullcalendar packages)*

------
https://chatgpt.com/codex/tasks/task_e_689a3be572948328bcc127ac4c5b4cf7