### PR TITLE
feat: integrate PostgreSQL backend and Zoho SMTP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,17 @@
-VITE_API_URL=http://localhost:3000
-SMTP_HOST=
-SMTP_PORT=
-SMTP_SECURE=false
-SMTP_USER=
-SMTP_PASS=
-MAIL_FROM="Gestão Leiteira <no-reply@example.com>"
-ENABLE_PREPARTO_JOB=false
-PREPARTO_WINDOW_DAYS=21
-# Base URL used to build password reset links
-AUTH_BASE_URL=http://localhost:5173
+# ===== Backend (.env) =====
+# Postgres
+DB_NAME=gestao_leiteira
+DB_USER=postgres
+DB_PASS=troque_aqui
+DB_HOST=localhost
+DB_PORT=5432
+PORT=3001
+
+# E-mail (Zoho)
+EMAIL_REMETENTE=seu_email@zohomail.com
+SENHA_REMETENTE=troque_aqui
+EMAIL_SERVICE=Zoho
+MAIL_FROM="Gestão Leiteira <seu_email@zohomail.com>"
+
+# JWT
+JWT_SECRET=troque_por_uma_chave_segura

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ backend/*.sqlite
 backend/*.sqlite3
 
 backend/package-lock.json
+.env

--- a/backend/config/env.js
+++ b/backend/config/env.js
@@ -1,0 +1,20 @@
+const path = require('path');
+require('dotenv').config({ path: path.resolve(process.cwd(), '..', '.env') });
+const cfg = {
+  db: {
+    host: process.env.DB_HOST || 'localhost',
+    port: +(process.env.DB_PORT || 5432),
+    user: process.env.DB_USER || 'postgres',
+    password: process.env.DB_PASS || '',
+    database: process.env.DB_NAME || 'gestao_leiteira',
+  },
+  port: +(process.env.PORT || 3001),
+  mail: {
+    service: process.env.EMAIL_SERVICE || 'Zoho',
+    user: process.env.EMAIL_REMETENTE,
+    pass: process.env.SENHA_REMETENTE,
+    from: process.env.MAIL_FROM || process.env.EMAIL_REMETENTE,
+  },
+  jwtSecret: process.env.JWT_SECRET || 'change_me',
+};
+module.exports = cfg;

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,15 +3,17 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "dev": "nodemon server.js",
+    "db:init": "node scripts/db-init.js"
   },
   "dependencies": {
-    "express": "^4.19.2",
-    "better-sqlite3": "^9.4.0",
-    "cors": "^2.8.5",
     "bcryptjs": "^2.4.3",
+    "cors": "^2.8.5",
+    "express": "^4.19.2",
     "jsonwebtoken": "^9.0.2",
-    "nodemailer": "^6.9.11"
+    "nodemailer": "^6.9.11",
+    "pg": "^8.11.3",
+    "dotenv": "^16.4.5"
   }
 }
-

--- a/backend/routes/healthDbRoutes.js
+++ b/backend/routes/healthDbRoutes.js
@@ -1,0 +1,7 @@
+const r = require('express').Router();
+const db = require('../services/dbAdapter');
+r.get('/api/v1/health/db', async (req, res, next) => {
+  try { await db.ping(); res.json({ ok:true, db:'up' }); }
+  catch (e) { next(e); }
+});
+module.exports = r;

--- a/backend/scripts/db-init.js
+++ b/backend/scripts/db-init.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+const { getPool } = require('../services/dbAdapter');
+
+(async () => {
+  const pool = getPool();
+  const sql = fs.readFileSync(path.resolve(__dirname, '../sql/schema.sql'), 'utf8');
+  await pool.query(sql);
+  console.log('✅ Schema aplicado');
+  process.exit(0);
+})().catch(err => {
+  console.error('❌ Falha ao aplicar schema:', err.message);
+  process.exit(1);
+});

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,7 @@
 require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
+const cfg = require('./config/env');
 const dbMiddleware = require('./middleware/dbMiddleware');
 const path = require('path');
 const fs = require('fs');
@@ -25,6 +26,7 @@ const authRoutes = require('./routes/authRoutes');
 const apiV1Routes = require('./routes/apiV1');
 const maintenanceRoutes = require('./routes/maintenanceRoutes');
 const healthRoutes = require('./routes/healthRoutes');
+const healthDbRoutes = require('./routes/healthDbRoutes');
 const logger = require('./middleware/logger');
 const rateLimit = require('./middleware/rateLimit');
 const errorHandler = require('./middleware/errorHandler');
@@ -81,6 +83,7 @@ app.use('/api', adminRoutes);
 app.use(apiV1Routes);
 app.use(maintenanceRoutes);
 app.use(healthRoutes);
+app.use(healthDbRoutes);
 
 // 🧾 Servir frontend estático (build do React)
 const distPath = path.join(__dirname, '..', 'dist');
@@ -95,7 +98,7 @@ app.get('*', (req, res) => {
 app.use(errorHandler);
 
 // 🚀 Inicialização do servidor (somente se executado diretamente)
-const PORT = process.env.PORT || 3000;
+const PORT = cfg.port;
 
 if (require.main === module) {
   const enablePrePartoJob = process.env.ENABLE_PREPARTO_JOB === 'true';

--- a/backend/services/dbAdapter.js
+++ b/backend/services/dbAdapter.js
@@ -1,25 +1,50 @@
-const { initDB, getDb } = require('../db');
+const { Pool } = require('pg');
+const cfg = require('../config/env');
 
-function query(sql, params = []) {
-  const db = getDb();
-  return db.prepare(sql).all(params);
+let pool;
+function getPool() {
+  if (!pool) {
+    pool = new Pool({
+      host: cfg.db.host,
+      port: cfg.db.port,
+      user: cfg.db.user,
+      password: cfg.db.password,
+      database: cfg.db.database,
+      max: 10,
+      idleTimeoutMillis: 30_000,
+      connectionTimeoutMillis: 10_000,
+    });
+  }
+  return pool;
 }
 
-function run(sql, params = []) {
-  const db = getDb();
-  return db.prepare(sql).run(params);
+async function query(text, params) {
+  const res = await getPool().query(text, params);
+  return res.rows;
+}
+async function run(text, params) {
+  await getPool().query(text, params);
+}
+async function tx(callback) {
+  const client = await getPool().connect();
+  try {
+    await client.query('BEGIN');
+    const result = await callback({
+      query: (t, p) => client.query(t, p),
+    });
+    await client.query('COMMIT');
+    return result;
+  } catch (e) {
+    await client.query('ROLLBACK');
+    throw e;
+  } finally {
+    client.release();
+  }
 }
 
-function transaction(cb) {
-  const db = getDb();
-  const trx = db.transaction(cb);
-  return trx();
+async function ping() {
+  await getPool().query('SELECT 1');
+  return true;
 }
 
-module.exports = {
-  initDB,
-  query,
-  run,
-  transaction,
-  getDb,
-};
+module.exports = { query, run, tx, ping, getPool };

--- a/backend/services/emailService.js
+++ b/backend/services/emailService.js
@@ -1,38 +1,29 @@
 const nodemailer = require('nodemailer');
-require('dotenv').config();
+const cfg = require('../config/env');
 
-const transporter = nodemailer.createTransport({
-  host: 'smtp.zoho.com',
-  port: 465,
-  secure: true,
-  auth: {
-    user: process.env.EMAIL_REMETENTE,
-    pass: process.env.EMAIL_SENHA_APP,
-  },
-});
+let transporter;
+function getTransporter() {
+  if (transporter) return transporter;
+  transporter = nodemailer.createTransport({
+    service: cfg.mail.service,
+    auth: { user: cfg.mail.user, pass: cfg.mail.pass }
+  });
+  return transporter;
+}
+
+async function sendMail(to, subject, html) {
+  const tr = getTransporter();
+  await tr.sendMail({ from: cfg.mail.from, to, subject, html });
+  return true;
+}
 
 async function sendCode(to, code) {
-  const message = {
-    from: process.env.EMAIL_REMETENTE,
-    to,
-    subject: 'Código de verificação - Gestão Leiteira',
-    text: `Seu código de verificação é: ${code}`,
-    headers: { 'X-Mailer': 'GestaoLeiteira' },
-    replyTo: 'no-reply@gestaoleiteira.com',
-  };
-  return transporter.sendMail(message);
+  const html = `<p>Seu código de verificação é: ${code}</p>`;
+  return sendMail(to, 'Código de verificação - Gestão Leiteira', html);
 }
 
 async function sendTemplate(to, subject, html) {
-  const message = {
-    from: process.env.EMAIL_REMETENTE,
-    to,
-    subject,
-    html,
-    headers: { 'X-Mailer': 'GestaoLeiteira' },
-    replyTo: 'no-reply@gestaoleiteira.com',
-  };
-  return transporter.sendMail(message);
+  return sendMail(to, subject, html);
 }
 
-module.exports = { sendCode, sendTemplate };
+module.exports = { sendMail, sendCode, sendTemplate };

--- a/backend/services/eventsService.js
+++ b/backend/services/eventsService.js
@@ -1,26 +1,25 @@
 const db = require('./dbAdapter');
-const eventosModel = require('../models/eventosModel');
 
-function registrarOcorrencia(idAnimal, dados) {
-  return eventosModel.create(
-    db.getDb(),
-    { animal_id: idAnimal, dataEvento: dados.data, tipoEvento: 'OCORRENCIA', descricao: dados.descricao || '' },
-    dados.idProdutor || null,
-  );
+async function registrarOcorrencia(idAnimal, dados) {
+  await db.run('INSERT INTO health_events (animal_id,tipo,data,payload) VALUES ($1,$2,$3,$4)', [
+    idAnimal,
+    'OCORRENCIA',
+    dados.data,
+    JSON.stringify(dados.payload || {}),
+  ]);
 }
 
-function registrarTratamento(idAnimal, dados) {
-  return eventosModel.create(
-    db.getDb(),
-    { animal_id: idAnimal, dataEvento: dados.data, tipoEvento: 'TRATAMENTO', descricao: dados.descricao || '' },
-    dados.idProdutor || null,
-  );
+async function registrarTratamento(idAnimal, dados) {
+  await db.run('INSERT INTO health_events (animal_id,tipo,data,payload) VALUES ($1,$2,$3,$4)', [
+    idAnimal,
+    'TRATAMENTO',
+    dados.data,
+    JSON.stringify(dados.payload || {}),
+  ]);
 }
 
-function listarHistorico(idAnimal) {
-  const todos = eventosModel.getByAnimal(db.getDb(), idAnimal, null);
-  const tipos = ['OCORRENCIA', 'TRATAMENTO'];
-  return todos.filter((e) => tipos.includes(e.tipoEvento));
+async function listarHistorico(idAnimal) {
+  return db.query('SELECT * FROM health_events WHERE animal_id=$1 ORDER BY data', [idAnimal]);
 }
 
 module.exports = {

--- a/backend/services/reproductionService.js
+++ b/backend/services/reproductionService.js
@@ -1,42 +1,43 @@
 const db = require('./dbAdapter');
-const eventosModel = require('../models/eventosModel');
 
-function registrarInseminacao(idAnimal, dados) {
-  return eventosModel.create(
-    db.getDb(),
-    { animal_id: idAnimal, dataEvento: dados.data, tipoEvento: 'INSEMINACAO', descricao: dados.descricao || '' },
-    dados.idProdutor || null,
-  );
+async function registrarInseminacao(idAnimal, dados) {
+  await db.run('INSERT INTO repro_events (animal_id,tipo,data,payload) VALUES ($1,$2,$3,$4)', [
+    idAnimal,
+    'IA',
+    dados.data,
+    JSON.stringify(dados.payload || {}),
+  ]);
 }
 
-function registrarDiagnostico(idAnimal, dados) {
-  return eventosModel.create(
-    db.getDb(),
-    { animal_id: idAnimal, dataEvento: dados.data, tipoEvento: 'DIAGNOSTICO', descricao: dados.descricao || '' },
-    dados.idProdutor || null,
-  );
+async function registrarDiagnostico(idAnimal, dados) {
+  await db.run('INSERT INTO repro_events (animal_id,tipo,data,payload) VALUES ($1,$2,$3,$4)', [
+    idAnimal,
+    'DIAGNOSTICO',
+    dados.data,
+    JSON.stringify(dados.payload || {}),
+  ]);
 }
 
-function registrarParto(idAnimal, dados) {
-  return eventosModel.create(
-    db.getDb(),
-    { animal_id: idAnimal, dataEvento: dados.data, tipoEvento: 'PARTO', descricao: dados.descricao || '' },
-    dados.idProdutor || null,
-  );
+async function registrarParto(idAnimal, dados) {
+  await db.run('INSERT INTO repro_events (animal_id,tipo,data,payload) VALUES ($1,$2,$3,$4)', [
+    idAnimal,
+    'PARTO',
+    dados.data,
+    JSON.stringify(dados.payload || {}),
+  ]);
 }
 
-function registrarSecagem(idAnimal, dados) {
-  return eventosModel.create(
-    db.getDb(),
-    { animal_id: idAnimal, dataEvento: dados.data, tipoEvento: 'SECAGEM', descricao: dados.descricao || '' },
-    dados.idProdutor || null,
-  );
+async function registrarSecagem(idAnimal, dados) {
+  await db.run('INSERT INTO repro_events (animal_id,tipo,data,payload) VALUES ($1,$2,$3,$4)', [
+    idAnimal,
+    'SECAGEM',
+    dados.data,
+    JSON.stringify(dados.payload || {}),
+  ]);
 }
 
-function listarHistorico(idAnimal) {
-  const todos = eventosModel.getByAnimal(db.getDb(), idAnimal, null);
-  const tipos = ['INSEMINACAO', 'DIAGNOSTICO', 'PARTO', 'SECAGEM'];
-  return todos.filter((e) => tipos.includes(e.tipoEvento));
+async function listarHistorico(idAnimal) {
+  return db.query('SELECT * FROM repro_events WHERE animal_id=$1 ORDER BY data', [idAnimal]);
 }
 
 module.exports = {

--- a/backend/sql/schema.sql
+++ b/backend/sql/schema.sql
@@ -1,0 +1,43 @@
+CREATE TABLE IF NOT EXISTS users (
+  id SERIAL PRIMARY KEY,
+  email TEXT UNIQUE NOT NULL,
+  password_hash TEXT,
+  verification_code TEXT,
+  verification_expires TIMESTAMP,
+  verified BOOLEAN DEFAULT false,
+  created_at TIMESTAMP DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS animals (
+  id SERIAL PRIMARY KEY,
+  numero TEXT,
+  brinco TEXT,
+  nascimento DATE,
+  raca TEXT,
+  estado TEXT DEFAULT 'vazia',
+  ultima_ia DATE,
+  diagnostico_data DATE,
+  diagnostico_resultado TEXT,
+  previsao_parto DATE,
+  parto DATE,
+  secagem DATE,
+  created_at TIMESTAMP DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS repro_events (
+  id SERIAL PRIMARY KEY,
+  animal_id INTEGER REFERENCES animals(id) ON DELETE CASCADE,
+  tipo TEXT NOT NULL, -- IA|DIAGNOSTICO|PARTO|SECAGEM
+  data DATE NOT NULL,
+  payload JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS health_events (
+  id SERIAL PRIMARY KEY,
+  animal_id INTEGER REFERENCES animals(id) ON DELETE CASCADE,
+  tipo TEXT NOT NULL, -- OCORRENCIA|TRATAMENTO
+  data DATE NOT NULL,
+  payload JSONB DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP DEFAULT now()
+);

--- a/docs/curl/animais-smoke-backend.sh
+++ b/docs/curl/animais-smoke-backend.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+BASE=${BASE:-http://localhost:3001}
+set -e
+echo "Criar animal:"; curl -s -X POST $BASE/api/v1/animais -H 'content-type: application/json' -d '{"numero":"A100","brinco":"A100","nascimento":"2024-01-10"}'; echo
+echo "Listar vazias:"; curl -s "$BASE/api/v1/animais?estado=vazia"; echo

--- a/docs/curl/auth-smoke.sh
+++ b/docs/curl/auth-smoke.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+BASE=${BASE:-http://localhost:3001}
+set -e
+echo "Register:"; curl -s -X POST $BASE/api/v1/auth/register -H 'content-type: application/json' -d '{"email":"dev+teste@example.com","password":"123456"}'; echo
+echo "Send code:"; curl -s -X POST $BASE/api/v1/auth/send-code -H 'content-type: application/json' -d '{"email":"dev+teste@example.com"}'; echo

--- a/docs/db/POSTGRES-SETUP.md
+++ b/docs/db/POSTGRES-SETUP.md
@@ -1,0 +1,22 @@
+# PostgreSQL — Setup
+1) Crie/edite o arquivo `.env` na raiz com seus dados (NÃO commite):
+   DB_NAME=gestao_leiteira
+   DB_USER=postgres
+   DB_PASS=...
+   DB_HOST=localhost
+   DB_PORT=5432
+   PORT=3001
+   EMAIL_REMETENTE=...
+   SENHA_REMETENTE=...
+   EMAIL_SERVICE=Zoho
+   MAIL_FROM="Gestão Leiteira <...>"
+   JWT_SECRET=...
+
+2) Inicie apenas o backend:
+   cd backend
+   npm i
+   npm run db:init
+   npm start  (ou npm run dev)
+
+3) Health:
+   GET http://localhost:3001/api/v1/health/db  -> { ok:true, db:'up' }


### PR DESCRIPTION
## Summary
- configure backend environment loader and `.env` template
- add PostgreSQL adapter, schema, initialization script, and DB health route
- wire up Zoho SMTP email service and update animal/reproduction/health services
- document Postgres setup and provide smoke-test cURL scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a85071cc08328ba948d7cc8e2780d