### PR TITLE
feat: add Postgres DB compat layer

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -31,7 +31,12 @@ const logger = require('./middleware/logger');
 const rateLimit = require('./middleware/rateLimit');
 const errorHandler = require('./middleware/errorHandler');
 const { inicializarAdmins } = require('./controllers/authController');
-const { initDB } = require('./db');
+const { initDB, getDb } = require('./db');
+
+(async () => {
+  await initDB('system@gestao'); // roda applyMigrations/abre pool
+  inicializarAdmins(getDb());
+})();
 
 const app = express();
 app.use(cors());
@@ -41,10 +46,6 @@ app.use(logger);
 
 // 📁 Pasta para backups de dados excluídos
 fs.mkdirSync(path.join(__dirname, 'dadosExcluidos'), { recursive: true });
-
-// 👤 Inicializa o admin padrão
-const adminDb = initDB('nandokkk@hotmail.com');
-inicializarAdmins(adminDb);
 
 // Importa middleware de autenticação para uso seletivo nas rotas protegidas
 const authMiddleware = require('./middleware/authMiddleware');

--- a/src/components/modals/ModalConfirmarExclusao.jsx
+++ b/src/components/modals/ModalConfirmarExclusao.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import "../styles/botoes.css";
+import "../../styles/botoes.css";
 
 export default function ModalConfirmarExclusao({
   mensagem = "Deseja realmente excluir este item?",

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -22,5 +22,5 @@ ReactDOM.createRoot(document.getElementById('root')).render(
 );
 // estilos FullCalendar
 import '@fullcalendar/common/main.css';
-import '@fullcalendar/daygrid/main.css';
-import '@fullcalendar/timegrid/main.css';
+import '@fullcalendar/daygrid/index.css';
+import '@fullcalendar/timegrid/index.css';


### PR DESCRIPTION
## Summary
- add sqlite-like adapter over pg so existing models keep using `prepare/get/all/run`
- ensure migrations run on server start before using models
- fix FullCalendar and button CSS imports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bc5754a888328abf92cf04286779a