### PR TITLE
refactor: use booleans and await db ops

### DIFF
--- a/backend/models/animaisModel.js
+++ b/backend/models/animaisModel.js
@@ -1,5 +1,5 @@
-function getAll(db, idProdutor) {
-  const tabelaExiste = db
+async function getAll(db, idProdutor) {
+  const tabelaExiste = await db
     .prepare(
       "SELECT name FROM sqlite_master WHERE type='table' AND name='ficha_complementar'",
     )
@@ -45,26 +45,28 @@ function getAll(db, idProdutor) {
         FROM animais a
         WHERE a.idProdutor = ?
       `;
-  return db.prepare(query).all(idProdutor);
+  return await db.prepare(query).all(idProdutor);
 }
 
-function getById(db, id, idProdutor) {
-  return db.prepare('SELECT * FROM animais WHERE id = ? AND idProdutor = ?').get(id, idProdutor);
+async function getById(db, id, idProdutor) {
+  return await db.prepare('SELECT * FROM animais WHERE id = ? AND idProdutor = ?').get(id, idProdutor);
 }
 
-function getByNumero(db, numero, idProdutor) {
-  return db.prepare('SELECT * FROM animais WHERE numero = ? AND idProdutor = ?').get(numero, idProdutor);
+async function getByNumero(db, numero, idProdutor) {
+  return await db.prepare('SELECT * FROM animais WHERE numero = ? AND idProdutor = ?').get(numero, idProdutor);
 }
 
-function getByEstado(db, estado, idProdutor = 1) {
-  return db.prepare('SELECT * FROM animais WHERE estado = ? AND idProdutor = ?').all(estado, idProdutor);
+async function getByEstado(db, estado, idProdutor = 1) {
+  return await db.prepare('SELECT * FROM animais WHERE estado = ? AND idProdutor = ?').all(estado, idProdutor);
 }
 
-function updateEstado(db, id, estado, idProdutor = 1) {
-  return db.prepare('UPDATE animais SET estado = ? WHERE id = ? AND idProdutor = ?').run(estado, id, idProdutor);
+async function updateEstado(db, id, estado, idProdutor = 1) {
+  return await db
+    .prepare('UPDATE animais SET estado = ? WHERE id = ? AND idProdutor = ?')
+    .run(estado, id, idProdutor);
 }
 
-function create(db, animal, idProdutor) {
+async function create(db, animal, idProdutor) {
   const stmt = db.prepare(`
     INSERT INTO animais (
       numero, brinco, nascimento, sexo, origem,
@@ -94,9 +96,9 @@ function create(db, animal, idProdutor) {
     categoria: animal.categoria || '',
     idade: animal.idade || '',
     raca: animal.raca || '',
-    checklistVermifugado: animal.checklistVermifugado ? 1 : 0,
-    checklistGrupoDefinido: animal.checklistGrupoDefinido ? 1 : 0,
-    fichaComplementarOK: animal.fichaComplementarOK ? 1 : 0,
+    checklistVermifugado: animal.checklistVermifugado ?? false,
+    checklistGrupoDefinido: animal.checklistGrupoDefinido ?? false,
+    fichaComplementarOK: animal.fichaComplementarOK ?? false,
     pai: animal.pai || '',
     mae: animal.mae || '',
     ultimaIA: animal.ultimaIA || '',
@@ -115,11 +117,11 @@ function create(db, animal, idProdutor) {
     idProdutor,
   };
 
-  const info = stmt.run(dados);
-  return getById(db, info.lastInsertRowid, idProdutor);
+  const info = await stmt.run(dados);
+  return await getById(db, info.lastInsertRowid, idProdutor);
 }
 
-function update(db, id, animal, idProdutor) {
+async function update(db, id, animal, idProdutor) {
   const stmt = db.prepare(`
     UPDATE animais SET
       numero = ?, brinco = ?, nascimento = ?, sexo = ?, origem = ?,
@@ -129,7 +131,7 @@ function update(db, id, animal, idProdutor) {
       status = ?, motivoSaida = ?, dataSaida = ?, valorVenda = ?, observacoesSaida = ?, tipoSaida = ?
     WHERE id = ? AND idProdutor = ?
   `);
-  stmt.run(
+  await stmt.run(
     animal.numero,
     animal.brinco,
     animal.nascimento,
@@ -138,9 +140,9 @@ function update(db, id, animal, idProdutor) {
     animal.categoria,
     animal.idade,
     animal.raca,
-    animal.checklistVermifugado ? 1 : 0,
-    animal.checklistGrupoDefinido ? 1 : 0,
-    animal.fichaComplementarOK ? 1 : 0,
+    animal.checklistVermifugado ?? false,
+    animal.checklistGrupoDefinido ?? false,
+    animal.fichaComplementarOK ?? false,
     animal.pai || '',
     animal.mae || '',
     animal.ultimaIA || '',
@@ -159,53 +161,61 @@ function update(db, id, animal, idProdutor) {
     id,
     idProdutor
   );
-  return getById(db, id, idProdutor);
+  return await getById(db, id, idProdutor);
 }
 
-function getIdByNumero(db, numero, idProdutor) {
-  const row = db.prepare('SELECT id FROM animais WHERE numero = ? AND idProdutor = ?').get(numero, idProdutor);
+async function getIdByNumero(db, numero, idProdutor) {
+  const row = await db
+    .prepare('SELECT id FROM animais WHERE numero = ? AND idProdutor = ?')
+    .get(numero, idProdutor);
   return row ? row.id : null;
 }
 
-function updateByNumero(db, numero, animal, idProdutor) {
-  const id = getIdByNumero(db, numero, idProdutor);
+async function updateByNumero(db, numero, animal, idProdutor) {
+  const id = await getIdByNumero(db, numero, idProdutor);
   if (!id) return null;
-  return update(db, id, { ...animal, numero }, idProdutor);
+  return await update(db, id, { ...animal, numero }, idProdutor);
 }
 
-function remove(db, id, idProdutor) {
-  return db.prepare('DELETE FROM animais WHERE id = ? AND idProdutor = ?').run(id, idProdutor);
+async function remove(db, id, idProdutor) {
+  return await db
+    .prepare('DELETE FROM animais WHERE id = ? AND idProdutor = ?')
+    .run(id, idProdutor);
 }
 
-function countByProdutor(db, idProdutor) {
-  const row = db.prepare('SELECT COUNT(*) as total FROM animais WHERE idProdutor = ?').get(idProdutor);
+async function countByProdutor(db, idProdutor) {
+  const row = await db
+    .prepare('SELECT COUNT(*) as total FROM animais WHERE idProdutor = ?')
+    .get(idProdutor);
   return row ? row.total : 0;
 }
 
 // Atualiza o status de um animal (1=lactante, 2=seca, 0=inativo)
-function updateStatus(db, id, status, idProdutor) {
-  db.prepare(`UPDATE animais SET status = ? WHERE id = ? AND idProdutor = ?`).run(status, id, idProdutor);
+async function updateStatus(db, id, status, idProdutor) {
+  await db
+    .prepare(`UPDATE animais SET status = ? WHERE id = ? AND idProdutor = ?`)
+    .run(status, id, idProdutor);
 }
 
 // Incrementa o número de lactações de um animal
-function incrementarLactacoes(db, id, idProdutor) {
-  db.prepare(
-    `UPDATE animais SET nLactacoes = COALESCE(nLactacoes, 0) + 1 WHERE id = ? AND idProdutor = ?`
-  ).run(id, idProdutor);
+async function incrementarLactacoes(db, id, idProdutor) {
+  await db
+    .prepare(
+      `UPDATE animais SET nLactacoes = COALESCE(nLactacoes, 0) + 1 WHERE id = ? AND idProdutor = ?`
+    )
+    .run(id, idProdutor);
 }
 
-function setDEL(db, id, del, idProdutor) {
-  db.prepare(`UPDATE animais SET del = ? WHERE id = ? AND idProdutor = ?`).run(
-    del,
-    id,
-    idProdutor,
-  );
+async function setDEL(db, id, del, idProdutor) {
+  await db
+    .prepare(`UPDATE animais SET del = ? WHERE id = ? AND idProdutor = ?`)
+    .run(del, id, idProdutor);
 }
 
 // Cria uma nova bezerra com o próximo número sequencial
-function createBezerra(db, dados, idProdutor) {
-  const max = db.prepare('SELECT MAX(numero) as m FROM animais WHERE idProdutor = ?')
-    .get(idProdutor)?.m || 0;
+async function createBezerra(db, dados, idProdutor) {
+  const max =
+    (await db.prepare('SELECT MAX(numero) as m FROM animais WHERE idProdutor = ?').get(idProdutor))?.m || 0;
   const numeroNovo = max + 1;
   const stmt = db.prepare(`
     INSERT INTO animais (
@@ -224,7 +234,7 @@ function createBezerra(db, dados, idProdutor) {
       null, ?
     )
   `);
-  const info = stmt.run(
+  const info = await stmt.run(
     numeroNovo,
     dados.brinco || '',
     dados.nascimento || '',
@@ -233,10 +243,14 @@ function createBezerra(db, dados, idProdutor) {
     'Bezerra',
     dados.idade || '',
     dados.raca || '',
-    0, 0, 0,
+    false,
+    false,
+    false,
     dados.pai || '',
     dados.mae || '',
-    null, null, 0,
+    null,
+    null,
+    0,
     idProdutor
   );
   return { id: info.lastInsertRowid, numero: numeroNovo, idProdutor };

--- a/backend/models/tarefasModel.js
+++ b/backend/models/tarefasModel.js
@@ -1,49 +1,49 @@
-function getAll(db, idProdutor) {
-  return db
+async function getAll(db, idProdutor) {
+  return await db
     .prepare('SELECT * FROM tarefas WHERE idProdutor = ?')
     .all(idProdutor);
 }
 
-function getById(db, id, idProdutor) {
-  return db
+async function getById(db, id, idProdutor) {
+  return await db
     .prepare('SELECT * FROM tarefas WHERE id = ? AND idProdutor = ?')
     .get(id, idProdutor);
 }
 
-function create(db, tarefa, idProdutor) {
+async function create(db, tarefa, idProdutor) {
   const stmt = db.prepare(`
     INSERT INTO tarefas (descricao, data, concluida, idProdutor)
     VALUES (?, ?, ?, ?)
   `);
-  const info = stmt.run(
+  const info = await stmt.run(
     tarefa.descricao,
     tarefa.data,
-    tarefa.concluida ? 1 : 0,
+    tarefa.concluida ?? false,
     idProdutor
   );
 
-  return getById(db, info.lastInsertRowid, idProdutor);
+  return await getById(db, info.lastInsertRowid, idProdutor);
 }
 
-function update(db, id, tarefa, idProdutor) {
+async function update(db, id, tarefa, idProdutor) {
   const stmt = db.prepare(`
     UPDATE tarefas
     SET descricao = ?, data = ?, concluida = ?
     WHERE id = ? AND idProdutor = ?
   `);
-  stmt.run(
+  await stmt.run(
     tarefa.descricao,
     tarefa.data,
-    tarefa.concluida ? 1 : 0,
+    tarefa.concluida ?? false,
     id,
     idProdutor
   );
 
-  return getById(db, id, idProdutor);
+  return await getById(db, id, idProdutor);
 }
 
-function remove(db, id, idProdutor) {
-  return db
+async function remove(db, id, idProdutor) {
+  return await db
     .prepare('DELETE FROM tarefas WHERE id = ? AND idProdutor = ?')
     .run(id, idProdutor);
 }

--- a/backend/routes/adminRoutes.js
+++ b/backend/routes/adminRoutes.js
@@ -16,8 +16,8 @@ router.get('/admin/dash', (req, res) => {
   res.json({ message: 'Bem-vindo ao painel de administração' });
 });
 
-router.get('/admin/produtores', (req, res) => {
-  const produtores = Produtor.getAll();
+router.get('/admin/produtores', async (req, res) => {
+  const produtores = await Produtor.getAll();
   const lista = produtores.map(p => {
     const fazenda = Fazenda.getByProdutor(p.id) || { nome: '', limiteAnimais: 0 };
     const total = Animal.countByProdutor(p.id);
@@ -40,11 +40,11 @@ router.patch('/admin/limite/:id', (req, res) => {
   res.json(fazenda);
 });
 
-router.patch('/admin/status/:id', (req, res) => {
-  const produtor = Produtor.getById(req.params.id);
+router.patch('/admin/status/:id', async (req, res) => {
+  const produtor = await Produtor.getById(req.params.id);
   if (!produtor) return res.status(404).json({ error: 'Produtor não encontrado' });
   const novoStatus = produtor.status === 'ativo' ? 'suspenso' : 'ativo';
-  Produtor.updateStatus(req.params.id, novoStatus);
+  await Produtor.updateStatus(req.params.id, novoStatus);
   res.json({ status: novoStatus });
 });
 
@@ -89,7 +89,7 @@ router.get('/admin/usuarios', async (req, res) => {
     if (dir === 'backups') continue;
     const email = unsanitizeEmail(dir);
     const db = initDB(email);
-    const usuarios = Usuario.getAll(db).filter(u => u.perfil !== 'admin');
+    const usuarios = (await Usuario.getAll(db)).filter(u => u.perfil !== 'admin');
 
     usuarios.forEach(u => {
       lista.push({

--- a/backend/routes/animaisRoutes.js
+++ b/backend/routes/animaisRoutes.js
@@ -14,10 +14,10 @@ router.use(authMiddleware);
 router.get('/', animaisController.listarAnimais);
 
 // 🔎 Buscar por número (deve vir antes do :id)
-router.get('/numero/:numero', (req, res) => {
+router.get('/numero/:numero', async (req, res) => {
   const db = initDB(req.user.email);
   try {
-    const animal = animaisModel.getByNumero(
+    const animal = await animaisModel.getByNumero(
       db,
       parseInt(req.params.numero),
       req.user.idProdutor
@@ -37,7 +37,7 @@ router.get('/:id', animaisController.buscarAnimalPorId);
 router.post('/', async (req, res, next) => {
   const db = initDB(req.user.email);
   const numero = parseInt(req.body.numero);
-  const existente = animaisModel.getByNumero(db, numero, req.user.idProdutor);
+  const existente = await animaisModel.getByNumero(db, numero, req.user.idProdutor);
   if (existente) {
     return res.status(400).json({ erro: 'Número já cadastrado' });
   }

--- a/backend/routes/reproducaoRoutes.js
+++ b/backend/routes/reproducaoRoutes.js
@@ -14,19 +14,19 @@ router.get('/:numero', (req, res) => {
   res.json(dados);
 });
 
-router.post('/', (req, res) => {
+router.post('/', async (req, res) => {
   const db = initDB(req.user.email);
   const dados = Reproducao.registrarIA(db, req.body, req.user.idProdutor);
   // Aciona serviços complementares (tarefas, estoque, etc.)
-  handleReproducao(db, req.body, req.user.idProdutor);
+  await handleReproducao(db, req.body, req.user.idProdutor);
   res.status(201).json(dados);
 });
 
-router.post('/diagnostico', (req, res) => {
+router.post('/diagnostico', async (req, res) => {
   const db = initDB(req.user.email);
   const dados = Reproducao.registrarDiagnostico(db, req.body, req.user.idProdutor);
   // Diagnóstico também aciona o serviço de reprodução
-  handleReproducao(db, req.body, req.user.idProdutor);
+  await handleReproducao(db, req.body, req.user.idProdutor);
   res.status(201).json(dados);
 });
 

--- a/backend/routes/tarefasRoutes.js
+++ b/backend/routes/tarefasRoutes.js
@@ -8,38 +8,38 @@ const autenticarToken = require('../middleware/autenticarToken');
 router.use(autenticarToken);
 
 // GET /tarefas → listar todas as tarefas do produtor
-router.get('/', (req, res) => {
+router.get('/', async (req, res) => {
   const db = initDB(req.user.email);
-  const tarefas = Tarefas.getAll(db, req.user.idProdutor);
+  const tarefas = await Tarefas.getAll(db, req.user.idProdutor);
   res.json(tarefas);
 });
 
 // GET /tarefas/:id → buscar uma tarefa específica
-router.get('/:id', (req, res) => {
+router.get('/:id', async (req, res) => {
   const db = initDB(req.user.email);
-  const tarefa = Tarefas.getById(db, parseInt(req.params.id), req.user.idProdutor);
+  const tarefa = await Tarefas.getById(db, parseInt(req.params.id), req.user.idProdutor);
   if (!tarefa) return res.status(404).json({ message: 'Tarefa não encontrada' });
   res.json(tarefa);
 });
 
 // POST /tarefas → criar nova tarefa
-router.post('/', (req, res) => {
+router.post('/', async (req, res) => {
   const db = initDB(req.user.email);
-  const tarefa = Tarefas.create(db, req.body, req.user.idProdutor);
+  const tarefa = await Tarefas.create(db, req.body, req.user.idProdutor);
   res.status(201).json(tarefa);
 });
 
 // PUT /tarefas/:id → editar tarefa
-router.put('/:id', (req, res) => {
+router.put('/:id', async (req, res) => {
   const db = initDB(req.user.email);
-  const tarefa = Tarefas.update(db, parseInt(req.params.id), req.body, req.user.idProdutor);
+  const tarefa = await Tarefas.update(db, parseInt(req.params.id), req.body, req.user.idProdutor);
   res.json(tarefa);
 });
 
 // DELETE /tarefas/:id → remover tarefa
-router.delete('/:id', (req, res) => {
+router.delete('/:id', async (req, res) => {
   const db = initDB(req.user.email);
-  Tarefas.remove(db, parseInt(req.params.id), req.user.idProdutor);
+  await Tarefas.remove(db, parseInt(req.params.id), req.user.idProdutor);
   res.status(204).end();
 });
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -22,5 +22,5 @@ ReactDOM.createRoot(document.getElementById('root')).render(
 );
 // estilos FullCalendar
 import '@fullcalendar/common/main.css';
-import '@fullcalendar/daygrid/index.css';
-import '@fullcalendar/timegrid/index.css';
+import '@fullcalendar/daygrid/dist/index.css';
+import '@fullcalendar/timegrid/dist/index.css';


### PR DESCRIPTION
## Summary
- switch verification flags to booleans and await SQL runs
- make DB model methods async and propagate `await` to controllers/routes
- fix FullCalendar CSS imports for Vite build

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bc98122f08328843b1dfb7f98517f