### PR TITLE
Ensure backend .env is loaded and fix FullCalendar CSS imports

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -2,4 +2,4 @@ PGHOST=localhost
 PGPORT=5432
 PGDATABASE=gestao_leiteira
 PGUSER=postgres
-PGPASSWORD=SuaSenhaAqui
+PGPASSWORD=SuaSenhaRealAqui

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,4 +1,6 @@
 // backend/db.js  — versão PostgreSQL
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '.env') });
 const { Pool } = require('pg');
 
 function sanitizeEmail(email) {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -21,6 +21,6 @@ ReactDOM.createRoot(document.getElementById('root')).render(
   </React.StrictMode>
 );
 // estilos FullCalendar
-import '@fullcalendar/common/main.css';
-import '@fullcalendar/daygrid/dist/index.css';
-import '@fullcalendar/timegrid/dist/index.css';
+import '@fullcalendar/core/index.css';
+import '@fullcalendar/daygrid/index.css';
+import '@fullcalendar/timegrid/index.css';


### PR DESCRIPTION
## Summary
- load backend/.env automatically in PostgreSQL pool
- store database credentials in backend/.env
- align FullCalendar CSS imports with version 6.1.x

## Testing
- `npm ls @fullcalendar/core @fullcalendar/react @fullcalendar/daygrid @fullcalendar/timegrid @fullcalendar/interaction`
- `npm test`
- `PGPASSWORD=SuaSenhaRealAqui psql -h localhost -U postgres -p 5432 -d gestao_leiteira -c "select now();"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689bd41c09688328ba6904e07af40c47