### PR TITLE
feat: add mailer utility and send verification

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -2,7 +2,7 @@ const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 const fs = require('fs');
 const Usuario = require('../models/Usuario');
-const { tx } = require('../utils/mailer');
+const { enviarCodigoVerificacao } = require('../mailer');
 const { initDB, getDBPath } = require('../db');
 const emailService = require('../services/emailService');
 const { setResetToken, getResetToken, deleteResetToken } = require('../services/userService');
@@ -77,16 +77,10 @@ async function cadastro(req, res) {
     });
 
     try {
-      await tx.sendMail({
-        from: process.env.MAIL_FROM,
-        to: endereco,
-        subject: 'Código de verificação - Gestão Leiteira',
-        text: `Seu código de verificação é: ${codigo}`,
-      });
-      console.log('✅ E-mail de verificação enviado para', endereco);
+      await enviarCodigoVerificacao(endereco, codigo);
     } catch (e) {
-      console.error('✉️  Falha ao enviar e-mail de verificação:', e);
-      // não derrube o cadastro por causa do e-mail em DEV
+      console.error('✉️  Falha ao enviar e-mail:', e);
+      // em DEV, não derrube a requisição por causa do e-mail
     }
     res.status(201).json({ message: 'Código enviado. Verifique o e-mail.' });
   } catch (error) {

--- a/backend/mailer.js
+++ b/backend/mailer.js
@@ -1,0 +1,33 @@
+const nodemailer = require('nodemailer');
+
+const transporter = process.env.EMAIL_SERVICE
+  ? nodemailer.createTransport({
+      service: process.env.EMAIL_SERVICE, // 'Zoho'
+      auth: {
+        user: process.env.EMAIL_REMETENTE,
+        pass: process.env.EMAIL_SENHA_APP
+      }
+    })
+  : nodemailer.createTransport({
+      host: process.env.SMTP_HOST || 'smtp.zoho.com',
+      port: Number(process.env.SMTP_PORT || 587),
+      secure: process.env.SMTP_SECURE === 'true', // false no 587
+      auth: {
+        user: process.env.EMAIL_REMETENTE,
+        pass: process.env.EMAIL_SENHA_APP
+      }
+    });
+
+async function enviarCodigoVerificacao(destinatario, codigo) {
+  const base = process.env.APP_BASE_URL || 'http://localhost:5173';
+  const link = `${base}/verificar?email=${encodeURIComponent(destinatario)}&codigo=${encodeURIComponent(codigo)}`;
+  const info = await transporter.sendMail({
+    from: process.env.MAIL_FROM || process.env.EMAIL_REMETENTE,
+    to: destinatario,
+    subject: 'Código de verificação',
+    html: `<p>Seu código: <b>${codigo}</b></p><p>Ou clique: <a href="${link}">${link}</a></p>`
+  });
+  console.log('✅ E-mail enviado:', info.messageId);
+}
+
+module.exports = { transporter, enviarCodigoVerificacao };


### PR DESCRIPTION
## Summary
- add nodemailer-based mailer helper
- send verification code with mailer during registration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cb7efcf048328b2d14252a00793e6