### PR TITLE
feat: support DB_* env vars for Postgres

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,5 +1,13 @@
-PGHOST=localhost
-PGPORT=5432
-PGDATABASE=gestao_leiteira
-PGUSER=postgres
-PGPASSWORD=SuaSenhaRealAqui
+DB_NAME=gestao_leiteira
+DB_USER=postgres
+DB_PASS=N@ndo1628
+DB_HOST=localhost
+DB_PORT=5432
+PORT=3001
+
+EMAIL_REMETENTE=gestaoleiteriasmartcow@gmail.com
+EMAIL_SENHA_APP=Sm@rtcow2025
+EMAIL_SERVICE=Zoho
+MAIL_FROM="Gestão Leiteira <gestaoleiteriasmartcow@gmail.com>"
+APP_BASE_URL=http://localhost:5173
+JWT_SECRET=troque_por_uma_chave_segura


### PR DESCRIPTION
## Summary
- load backend .env and create Pool config that accepts DB_* or PG* variables
- add diagnostic logging and enforce string/number types for DB credentials
- document backend environment variables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689cbc45bda88328ba7426067469b053