### PR TITLE
refactor: flexible SMTP configuration with simple checker

### DIFF
--- a/backend/utils/_smtp_check.js
+++ b/backend/utils/_smtp_check.js
@@ -1,26 +1,11 @@
-require("dotenv").config();
-const nodemailer = require("nodemailer");
-
-let host = process.env.SMTP_HOST || "smtp.zoho.com";
-let port = Number(process.env.SMTP_PORT || 465);
-let secure = (String(process.env.SMTP_SECURE || "true").toLowerCase() !== "false");
-const user = process.env.EMAIL_REMETENTE;
-const pass = process.env.EMAIL_SENHA_APP;
-
-if (/@gmail\.com$/i.test(user) && /zoho/i.test(host)) {
-  host = "smtp.gmail.com"; port = 465; secure = true;
-}
-
-const t = nodemailer.createTransport({ host, port, secure, auth: { user, pass } });
+require('dotenv').config();
+const { verifyConnection } = require('./email');
 
 (async () => {
-  console.log("[SMTP CHECK] tentando login em", { host, port, secure, user });
   try {
-    await t.verify();
-    console.log("✅ Login SMTP OK");
-    process.exit(0);
-  } catch (e) {
-    console.error("❌ Falhou:", e?.message || e);
-    process.exit(2);
+    await verifyConnection();
+  } catch {
+    process.exit(1);
   }
 })();
+


### PR DESCRIPTION
## Summary
- refactor email utility to support generic SMTP hosts and log config
- export `verifyConnection` and create simple `_smtp_check` verifier

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a07e5bf9f483288e10b073e0b73ab8