### PR TITLE
Configure Zoho SMTP and add verification helper

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -1,18 +1,15 @@
-# App
-APP_BASE_URL=http://localhost:5173
-JWT_SECRET=sua_chave_bem_grande_aqui
+# ==== AUTH ====
+JWT_SECRET=1cbedad375d9d3d42b763b3c1651d773722e244845717fe4c219bb78dd2399e33129799a10f173f2aab96674033e199d
 
-# Postgres (já está funcionando)
-PGHOST=localhost
-PGPORT=5432
-PGDATABASE=gestao_leiteira
-PGUSER=postgres
-PGPASSWORD="N@ndo1628"
-
-# E-mail (Zoho - conta Gmail adicionada no Zoho)
+# ==== SMTP (ZOHO) ====
+SMTP_PROVIDER=zoho
 SMTP_HOST=smtp.zoho.com
 SMTP_PORT=465
 SMTP_SECURE=true
-EMAIL_REMETENTE=gestaoleiteirasmartcow@gmail.com
-EMAIL_SENHA_APP=Sm@rtcow2025
-MAIL_FROM="Gestão Leiteira <gestaoleiteirasmartcow@gmail.com>"
+EMAIL_REMETENTE=gestaoleiteirasmartcow@zohomail.com
+EMAIL_SENHA_APP=abcdefghijklmnop
+MAIL_FROM="Gestão Leiteira <gestaoleiteirasmartcow@zohomail.com>"
+
+# ==== UTIL ====
+VERIFICATION_TTL_MINUTES=3
+LOG_ENV_PATH=true


### PR DESCRIPTION
## Summary
- Configure backend .env for Zoho SMTP settings and utility flags
- Replace email utility to log SMTP config and verify auth before sending
- Add `_smtp_check.js` script to locally test SMTP connectivity

## Testing
- `node backend/utils/_smtp_check.js` *(fails: connect ENETUNREACH)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a08910563c832887d9d5b92d2224a0