### PR TITLE
chore: load env fallbacks and validate DB password

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,9 +1,10 @@
-require('dotenv').config();
+const path = require('path');
+require('dotenv').config(); // backend/.env
+require('dotenv').config({ path: path.join(__dirname, '..', '.env') }); // fallback: .env da raiz
 const express = require('express');
 const cors = require('cors');
 const cfg = require('./config/env');
 const dbMiddleware = require('./middleware/dbMiddleware');
-const path = require('path');
 const fs = require('fs');
 let morgan; try { morgan = require('morgan'); } catch {}
 


### PR DESCRIPTION
## Summary
- load backend and root `.env` files in db layer
- ensure DB password is required and normalize credentials before creating pool
- load root `.env` as fallback in backend server

## Testing
- `PGPASSWORD=dummy npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a08e81e42c8328b767ded18f13dc8e